### PR TITLE
Improve performance and fix bugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ noise = { version = "0.9.0" }
 rand = { version = "0.9.0" }
 serde = { version = "1.0.217", features = ["derive"] }
 bevy_common_assets = { version = "0.12.0", features = ["ron"] }
+iyes_perf_ui = "0.4.0"
 
 #[profile.dev]
 #opt-level = 1

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ This way, you'll just need to `direnv allow` in the project directory after whic
 all Bevy dependencies, etc.) will be available to you. The JetBrains plugin will ensure that the environment is
 available to your IDE and you can run the project from there (vs `cargo build` and `cargo run` in the terminal).
 
+##### How to deal with RustRover making problems again
+
+RustRover forgetting where the Rust standard library is?
+```
+find /nix/store -type d -name rust_lib_src
+```
+
 ### Using Nix Flakes
 
 Without `direnv`, you can use the Nix Flake by running `nix develop` in the project directory. If you want to use an IDE

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ techniques.
 
 ## Demo
 
+[![YouTube - Demo](https://img.youtube.com/vi/rdGre9dZdgo/0.jpg)](https://www.youtube.com/watch?v=rdGre9dZdgo)
 ![Screenshot 1](assets/ignore/screenshot1.png)
 ![Screenshot 2](assets/ignore/screenshot2.png)
 ![Demo GIF 3](assets/ignore/demo3.gif)
 ![Demo GIF 1](assets/ignore/demo1.gif)
 ![Demo GIF 4](assets/ignore/demo4.gif)
 ![Demo GIF 2](assets/ignore/demo2.gif)
-![Screenshot 3](assets/ignore/screenshot3.png)
 
 ## Features
 
@@ -62,6 +62,7 @@ available to your IDE and you can run the project from there (vs `cargo build` a
 ##### How to deal with RustRover making problems again
 
 RustRover forgetting where the Rust standard library is?
+
 ```
 find /nix/store -type d -name rust_lib_src
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ techniques.
 - Executes generation processes asynchronously (excluding entity spawning, of course)
 - Terrain generation:
     - Uses multi-fractal Perlin noise to generate terrain layers
-    - Features 3 biomes (dry, moderate, humid), each with 5 terrain types (water, shore, and three land layers e.g. sand/grass/forest)
+    - Features 3 biomes (dry, moderate, humid), each with 5 terrain types (water, shore, and three land layers e.g.
+      sand/grass/forest)
     - Each terrain type supports 16 different tile types, many with transparency allowing for smooth
       transitions/layering
     - Uses a deterministic chunk-based approach (as can be seen in the GIFs)
@@ -77,8 +78,25 @@ Upgrade the flake by running `nix flake update` in the repository's base directo
 5. Add a new state to the relevant `{terrain}.terrain.ruleset.ron` file using the index from the sprite sheet
 6. Optional: if this is a large asset, make sure to add it to `ObjectName.is_large_sprite()` too
 
+#### How to use cargo-flamegraph
+
+- Run the command below to generate a flame graph
+    - Linux:
+      ```shell
+      CARGO_PROFILE_RELEASE_DEBUG=true RUSTFLAGS='-C force-frame-pointers=y' cargo flamegraph -c "record -g" --package=procedural-generation-2 --bin=procedural-generation-2
+      ```
+    - Windows:
+      ```pwsh
+      $env:CARGO_PROFILE_RELEASE_DEBUG = "true"; $env:RUSTFLAGS = "-C force-frame-pointers=y"; cargo flamegraph -c "record -g" --package=procedural-generation-2 --bin=procedural-generation-2
+      ````
+- This should run the application - once you close it, a `flamegraph.svg` will be generated at the root of the
+  repository
+- Open it in your browser to see the flame graph
+
 #### Run configurations
 
 - Create a run configuration with environment variable `RUST_LOG=procedural_generation_2=debug` for debug logs
 - Create a run configuration with environment variable
   `RUST_LOG=procedural_generation_2=debug,procedural_generation_2::generation::object=trace` to add WFC trace logs too
+- Create a run configuration with environment variable `RUST_LOG=bevy_ecs=debug` to see Bevy ECS logs (e.g. which system
+  caused an `error[B0003]`)

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1738453229,
-        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
+        "lastModified": 1741352980,
+        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
+        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739019272,
-        "narHash": "sha256-7Fu7oazPoYCbDzb9k8D/DdbKrC3aU1zlnc39Y8jy/s8=",
+        "lastModified": 1741402956,
+        "narHash": "sha256-y2hByvBM03s9T2fpeLjW6iprbxnhV9mJMmSwCHc41ZQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa35a3c8e17a3de613240fea68f876e5b4896aec",
+        "rev": "ed0b1881565c1ffef490c10d663d4f542031dad3",
         "type": "github"
       },
       "original": {
@@ -35,14 +35,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1738452942,
-        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+        "lastModified": 1740877520,
+        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
@@ -73,11 +76,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1739068147,
-        "narHash": "sha256-3DtLkjQFlIUOXw3TBH+iP0jglpqO6Lv2KaQc+ADg39I=",
+        "lastModified": 1741573199,
+        "narHash": "sha256-A2sln1GdCf+uZ8yrERSCZUCqZ3JUlOv1WE2VFqqfaLQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f61820fa2c3844d6940cce269a6afdec30aa2e6c",
+        "rev": "c777dc8a1e35407b0e80ec89817fe69970f4e81a",
         "type": "github"
       },
       "original": {

--- a/src/animations.rs
+++ b/src/animations.rs
@@ -1,16 +1,22 @@
-use crate::components::AnimationComponent;
+#![allow(unused_imports, dead_code)]
+
+use crate::components::{AnimationMeshComponent, AnimationSpriteComponent};
 use bevy::app::{App, Plugin};
-use bevy::prelude::{Query, Res, Sprite, Time, Update};
+use bevy::asset::Assets;
+use bevy::prelude::{Mesh, Mesh2d, Query, Res, ResMut, Sprite, Time, Update};
+use bevy::render::mesh::VertexAttributeValues;
 
 pub struct AnimationsPlugin;
 
 impl Plugin for AnimationsPlugin {
   fn build(&self, app: &mut App) {
-    app.add_systems(Update, sprite_animation_system);
+    app
+      // .add_systems(Update, sprite_animation_system) // Use once animated objects are used
+      .add_systems(Update, animate_tile_meshes);
   }
 }
 
-fn sprite_animation_system(time: Res<Time>, mut query: Query<(&mut AnimationComponent, &mut Sprite)>) {
+fn sprite_animation_system(time: Res<Time>, mut query: Query<(&mut AnimationSpriteComponent, &mut Sprite)>) {
   for (mut ac, mut sprite) in &mut query {
     ac.timer.tick(time.delta());
     if ac.timer.just_finished() {
@@ -20,6 +26,50 @@ fn sprite_animation_system(time: Res<Time>, mut query: Query<(&mut AnimationComp
         } else {
           atlas.index + 1
         };
+      }
+    }
+  }
+}
+
+fn animate_tile_meshes(
+  time: Res<Time>,
+  mut meshes: ResMut<Assets<Mesh>>,
+  mut query: Query<(&mut AnimationMeshComponent, &Mesh2d)>,
+) {
+  for (mut anim_mesh_component, mesh_2d) in &mut query {
+    anim_mesh_component.timer.tick(time.delta());
+    if anim_mesh_component.timer.just_finished() {
+      anim_mesh_component.current_frame = (anim_mesh_component.current_frame + 1) % anim_mesh_component.frame_count;
+      if let Some(mesh) = meshes.get_mut(mesh_2d) {
+        if let Some(uv_attribute) = mesh.attribute_mut(Mesh::ATTRIBUTE_UV_0) {
+          if let VertexAttributeValues::Float32x2(uvs) = uv_attribute {
+            let mut tile_index = 0;
+            for i in 0..uvs.len() / 4 {
+              let base_sprite_index = anim_mesh_component.tile_indices[tile_index];
+              let frame_offset = anim_mesh_component.current_frame;
+              let sprite_index = base_sprite_index + frame_offset;
+              let sprite_col = sprite_index as f32 % anim_mesh_component.columns;
+              let sprite_row = (sprite_index as f32 / anim_mesh_component.columns).floor();
+
+              let u_start = sprite_col / anim_mesh_component.columns;
+              let u_end = (sprite_col + 1.0) / anim_mesh_component.columns;
+              let v_start = sprite_row / anim_mesh_component.rows;
+              let v_end = (sprite_row + 1.0) / anim_mesh_component.rows;
+
+              let vertex_base = i * 4;
+              uvs[vertex_base] = [u_start, v_start]; // Top-left
+              uvs[vertex_base + 1] = [u_end, v_start]; // Top-right
+              uvs[vertex_base + 2] = [u_end, v_end]; // Bottom-right
+              uvs[vertex_base + 3] = [u_start, v_end]; // Bottom-left
+
+              tile_index += 1;
+
+              if tile_index >= anim_mesh_component.tile_indices.len() {
+                break;
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -41,7 +41,7 @@ fn setup_camera_system(mut commands: Commands) {
       speed: 600.,
       zoom_to_cursor: false,
       min_scale: 0.15,
-      max_scale: 5.,
+      max_scale: 10.,
       ..default()
     },
   ));

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,4 +1,7 @@
-use crate::constants::WATER_BLUE;
+use crate::constants::{CHUNK_SIZE, TILE_SIZE, WATER_BLUE};
+use crate::coords::Point;
+use crate::events::UpdateWorldEvent;
+use crate::resources::CurrentChunk;
 use bevy::app::{App, Plugin, Startup};
 use bevy::core_pipeline::bloom::Bloom;
 use bevy::prelude::*;
@@ -12,8 +15,9 @@ pub struct CameraPlugin;
 impl Plugin for CameraPlugin {
   fn build(&self, app: &mut App) {
     app
+      .insert_resource(ClearColor(WATER_BLUE))
       .add_systems(Startup, setup_camera_system)
-      .insert_resource(ClearColor(WATER_BLUE));
+      .add_systems(Update, camera_movement_system);
   }
 }
 
@@ -45,4 +49,32 @@ fn setup_camera_system(mut commands: Commands) {
       ..default()
     },
   ));
+}
+
+fn camera_movement_system(
+  camera: Query<(&Camera, &GlobalTransform)>,
+  current_chunk: Res<CurrentChunk>,
+  mut event: EventWriter<UpdateWorldEvent>,
+) {
+  let translation = camera.single().1.translation();
+  let current_world = Point::new_world_from_world_vec2(translation.truncate());
+  let chunk_center_world = current_chunk.get_center_world();
+  let distance_x = (current_world.x - chunk_center_world.x).abs();
+  let distance_y = (current_world.y - chunk_center_world.y).abs();
+  let trigger_distance = ((CHUNK_SIZE * TILE_SIZE as i32) / 2) + 1;
+  trace!(
+    "Camera moved to {:?} with distance x={:?}, y={:?} (trigger distance {})",
+    current_world,
+    distance_x,
+    distance_y,
+    trigger_distance
+  );
+
+  if (distance_x >= trigger_distance) || (distance_y >= trigger_distance) {
+    event.send(UpdateWorldEvent {
+      is_forced_update: false,
+      tg: Point::new_tile_grid_from_world(current_world),
+      w: current_world,
+    });
+  };
 }

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::{Component, Deref, DerefMut, Timer};
 
 #[derive(Component)]
-pub struct AnimationComponent {
+pub struct AnimationSpriteComponent {
   pub(crate) index_first: usize,
   pub(crate) index_last: usize,
   pub(crate) timer: AnimationTimer,
@@ -9,3 +9,13 @@ pub struct AnimationComponent {
 
 #[derive(Component, Deref, DerefMut)]
 pub struct AnimationTimer(pub Timer);
+
+#[derive(Component)]
+pub struct AnimationMeshComponent {
+  pub(crate) timer: AnimationTimer,
+  pub(crate) frame_count: usize,
+  pub(crate) current_frame: usize,
+  pub(crate) columns: f32,
+  pub(crate) rows: f32,
+  pub(crate) tile_indices: Vec<usize>,
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -39,6 +39,7 @@ pub const GENERATE_OBJECTS: bool = true;
 pub const ENABLE_COLOUR_VARIATIONS: bool = false;
 // ------------------------------------------------------------------------------------------------------
 // Chunks and tiles
+pub const MAX_CHUNKS: usize = 9;
 /// The size of a buffer around a chunk that is generated but not rendered. Must be 1, always.
 pub const BUFFER_SIZE: i32 = 1;
 /// The size of a chunk, including a border that will not be rendered. This is to ensure that the

--- a/src/controls.rs
+++ b/src/controls.rs
@@ -1,6 +1,6 @@
-use crate::constants::{CHUNK_SIZE, ORIGIN_TILE_GRID_SPAWN_POINT, TILE_SIZE};
+use crate::constants::ORIGIN_TILE_GRID_SPAWN_POINT;
 use crate::coords::Point;
-use crate::events::{MouseClickEvent, RefreshMetadata, ToggleDebugInfo, UpdateWorldEvent};
+use crate::events::{MouseClickEvent, RefreshMetadata, ToggleDebugInfo};
 use crate::resources::{CurrentChunk, GeneralGenerationSettings, ObjectGenerationSettings, Settings};
 use bevy::app::{App, Plugin};
 use bevy::prelude::*;
@@ -12,12 +12,7 @@ impl Plugin for ControlPlugin {
   fn build(&self, app: &mut App) {
     app.add_systems(
       Update,
-      (
-        event_control_system,
-        settings_controls_system,
-        left_mouse_click_system,
-        camera_movement_system,
-      ),
+      (event_control_system, settings_controls_system, left_mouse_click_system),
     );
   }
 }
@@ -119,32 +114,4 @@ fn left_mouse_click_system(
       commands.trigger(MouseClickEvent { tile_w, cg, tg });
     }
   }
-}
-
-fn camera_movement_system(
-  camera: Query<(&Camera, &GlobalTransform)>,
-  current_chunk: Res<CurrentChunk>,
-  mut event: EventWriter<UpdateWorldEvent>,
-) {
-  let translation = camera.single().1.translation();
-  let current_world = Point::new_world_from_world_vec2(translation.truncate());
-  let chunk_center_world = current_chunk.get_center_world();
-  let distance_x = (current_world.x - chunk_center_world.x).abs();
-  let distance_y = (current_world.y - chunk_center_world.y).abs();
-  let trigger_distance = ((CHUNK_SIZE * TILE_SIZE as i32) / 2) + 1;
-  trace!(
-    "Camera moved to {:?} with distance x={:?}, y={:?} (trigger distance {})",
-    current_world,
-    distance_x,
-    distance_y,
-    trigger_distance
-  );
-
-  if (distance_x >= trigger_distance) || (distance_y >= trigger_distance) {
-    event.send(UpdateWorldEvent {
-      is_forced_update: false,
-      tg: Point::new_tile_grid_from_world(current_world),
-      w: current_world,
-    });
-  };
 }

--- a/src/controls.rs
+++ b/src/controls.rs
@@ -74,15 +74,15 @@ fn settings_controls_system(
     settings.general.animate_terrain_sprites = !settings.general.animate_terrain_sprites;
     general_settings.animate_terrain_sprites = settings.general.animate_terrain_sprites;
     info!(
-      "[V] Set animating terrain sprites to [{}]",
+      "[B] Set animating terrain sprites to [{}]",
       settings.general.animate_terrain_sprites
     );
   }
 
-  if keyboard_input.just_pressed(KeyCode::KeyB) {
+  if keyboard_input.just_pressed(KeyCode::KeyN) {
     settings.general.enable_world_pruning = !settings.general.enable_world_pruning;
     general_settings.enable_world_pruning = settings.general.enable_world_pruning;
-    info!("[B] Set world pruning to [{}]", settings.general.enable_world_pruning);
+    info!("[N] Set world pruning to [{}]", settings.general.enable_world_pruning);
   }
 
   if keyboard_input.just_pressed(KeyCode::KeyF) {

--- a/src/controls.rs
+++ b/src/controls.rs
@@ -84,6 +84,12 @@ fn settings_controls_system(
     );
   }
 
+  if keyboard_input.just_pressed(KeyCode::KeyB) {
+    settings.general.enable_world_pruning = !settings.general.enable_world_pruning;
+    general_settings.enable_world_pruning = settings.general.enable_world_pruning;
+    info!("[B] Set world pruning to [{}]", settings.general.enable_world_pruning);
+  }
+
   if keyboard_input.just_pressed(KeyCode::KeyF) {
     settings.object.generate_objects = !settings.object.generate_objects;
     object_settings.generate_objects = settings.object.generate_objects;

--- a/src/coords/point.rs
+++ b/src/coords/point.rs
@@ -117,6 +117,7 @@ impl<T: CoordType> Point<T> {
     }
   }
 
+  // TODO: Consider changing implementation for InternalGrid point
   pub fn from_direction(direction: &Direction) -> Self {
     let (i, j) = match direction {
       Direction::TopLeft => (-1, 1),
@@ -209,5 +210,87 @@ impl Point<ChunkGrid> {
       ((w.x as f32 + 1.) / (TILE_SIZE as f32 * CHUNK_SIZE as f32)).round() as i32,
       ((w.y as f32 - 1.) / (TILE_SIZE as f32 * CHUNK_SIZE as f32)).round() as i32,
     )
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use bevy::prelude::Vec2;
+
+  #[test]
+  fn internal_grid_point_creation() {
+    let p = Point::new_internal_grid(5, 6);
+    assert_eq!(p.x, 5);
+    assert_eq!(p.y, 6);
+    assert_eq!(p._marker, std::marker::PhantomData::<InternalGrid>);
+  }
+
+  #[test]
+  fn world_point_creation() {
+    let p = Point::new_world(10, 20);
+    assert_eq!(p.x, 10);
+    assert_eq!(p.y, 20);
+    assert_eq!(p._marker, std::marker::PhantomData::<World>);
+  }
+
+  #[test]
+  fn tile_grid_point_creation() {
+    let p = Point::new_tile_grid(2, 13);
+    assert_eq!(p.x, 2);
+    assert_eq!(p.y, 13);
+    assert_eq!(p._marker, std::marker::PhantomData::<TileGrid>);
+  }
+
+  #[test]
+  fn point_creation_from_direction_1() {
+    let direction = Direction::TopLeft;
+    let point: Point<World> = Point::from_direction(&direction);
+    assert_eq!(point, Point::new(-1, 1));
+  }
+
+  #[test]
+  fn point_creation_from_direction_2() {
+    let direction = Direction::TopLeft;
+    let point: Point<InternalGrid> = Point::from_direction(&direction);
+    assert_eq!(point, Point::new(-1, 1));
+  }
+
+  #[test]
+  fn tile_grid_point_creation_from_world() {
+    let w = Point::new_world(TILE_SIZE as i32, TILE_SIZE as i32);
+    let tg = Point::new_tile_grid_from_world(w);
+    assert_eq!(tg, Point::new_tile_grid(1, 1));
+  }
+
+  #[test]
+  fn chunk_grid_point_creation_from_world() {
+    let w = Point::new_world(TILE_SIZE as i32 * CHUNK_SIZE * 2, TILE_SIZE as i32 * CHUNK_SIZE * 2);
+    let cg = Point::new_chunk_grid_from_world(w);
+    assert_eq!(cg, Point::new_chunk_grid(2, 2));
+  }
+
+  #[test]
+  fn point_addition() {
+    let p1: Point<InternalGrid> = Point::new(1, 2);
+    let p2 = Point::new(3, 4);
+    let result = p1 + p2;
+    assert_eq!(result, Point::new(4, 6));
+    assert_eq!(result._marker, std::marker::PhantomData::<InternalGrid>);
+  }
+
+  #[test]
+  fn point_distance() {
+    let p1: Point<TileGrid> = Point::new(0, 0);
+    let p2 = Point::new(3, 4);
+    let distance = p1.distance_to(&p2);
+    assert_eq!(distance, 5.0);
+  }
+
+  #[test]
+  fn point_to_vec2() {
+    let p: Point<ChunkGrid> = Point::new(1, 2);
+    let vec = p.to_vec2();
+    assert_eq!(vec, Vec2::new(1.0, 2.0));
   }
 }

--- a/src/coords/point.rs
+++ b/src/coords/point.rs
@@ -117,7 +117,7 @@ impl<T: CoordType> Point<T> {
     }
   }
 
-  // TODO: Consider changing implementation for InternalGrid point
+  // TODO: Consider changing implementation for InternalGrid point because top/bottom directions are flipped when used
   pub fn from_direction(direction: &Direction) -> Self {
     let (i, j) = match direction {
       Direction::TopLeft => (-1, 1),

--- a/src/generation/lib/chunk.rs
+++ b/src/generation/lib/chunk.rs
@@ -122,7 +122,7 @@ fn generate_terrain_data(
     ix = 0;
   }
   trace!(
-    "Generated draft chunk at {:?} in {} ms on [{}]",
+    "Generated draft chunk at {:?} in {} ms on {}",
     tg,
     shared::get_time() - start_time,
     shared::thread_name()

--- a/src/generation/lib/chunk.rs
+++ b/src/generation/lib/chunk.rs
@@ -10,6 +10,11 @@ use noise::{BasicMulti, MultiFractal, NoiseFn, Perlin};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
+const INSIDE: i32 = 1;
+const OUTSIDE: i32 = CHUNK_SIZE + 1;
+const EXPANDED_INSIDE: i32 = 2;
+const EXPANDED_OUTSIDE: i32 = CHUNK_SIZE;
+
 /// A `Chunk` represents a single chunk of the world.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Chunk {
@@ -32,20 +37,6 @@ impl Chunk {
       layered_plane,
     }
   }
-}
-
-// TODO: Consider removing this struct
-#[derive(Debug, Clone, PartialEq)]
-struct Distances {
-  top_left: f64,
-  top: f64,
-  top_right: f64,
-  left: f64,
-  center: f64,
-  right: f64,
-  bottom_left: f64,
-  bottom: f64,
-  bottom_right: f64,
 }
 
 /// Generates terrain data for a draft chunk based on Perlin noise. Expects `tg` to be a `Point` of type
@@ -91,11 +82,9 @@ fn generate_terrain_data(
       let elevation_offset = elevation_metadata.calculate_for_point(ig, CHUNK_SIZE, BUFFER_SIZE);
       let normalised_noise = ((normalised_noise * strength) + elevation_offset).clamp(0., 1.);
 
-      // Calculate distances to chunk edge in all directions
-      let distances = calculate_distances(start, end, center, max_distance, tx, ty);
-
       // Calculate if this tile is a biome edge
-      let is_biome_edge = is_tile_at_edge_of_biome(ix, iy, distances.center, &biome_metadata, &mut rng);
+      let distance_from_center = calculate_distance_from_center(center, max_distance, tx, ty);
+      let is_biome_edge = is_tile_at_edge_of_biome(ix, iy, distance_from_center, &biome_metadata, &mut rng);
 
       // Create debug data for troubleshooting
       let debug_data = DebugData {
@@ -131,37 +120,12 @@ fn generate_terrain_data(
   tiles
 }
 
-fn calculate_distances(
-  start: Point<TileGrid>,
-  end: Point<TileGrid>,
-  center: Point<TileGrid>,
-  max_distance: f64,
-  tx: i32,
-  ty: i32,
-) -> Distances {
+fn calculate_distance_from_center(center: Point<TileGrid>, max_distance: f64, tx: i32, ty: i32) -> f64 {
   let distance_x = (tx - center.x).abs() as f64 / max_distance;
   let distance_y = (ty - center.y).abs() as f64 / max_distance;
-  let distance_from_center = distance_x.max(distance_y);
-  let distances = Distances {
-    top_left: (((tx - start.x).pow(2) + (ty - start.y).pow(2)) as f64).sqrt() / max_distance,
-    top: (ty - start.y).abs() as f64 / max_distance,
-    top_right: (((end.x - tx).pow(2) + (ty - start.y).pow(2)) as f64).sqrt() / max_distance,
-    left: (tx - start.x).abs() as f64 / max_distance,
-    center: distance_from_center,
-    right: (end.x - tx).abs() as f64 / max_distance,
-    bottom_left: (((tx - start.x).pow(2) + (end.y - ty).pow(2)) as f64).sqrt() / max_distance,
-    bottom: (end.y - ty).abs() as f64 / max_distance,
-    bottom_right: (((end.x - tx).pow(2) + (end.y - ty).pow(2)) as f64).sqrt() / max_distance,
-  };
-  trace!("tg({}, {}): Distances = {:?}", tx, ty, distances);
 
-  distances
+  distance_x.max(distance_y)
 }
-
-const INSIDE: i32 = 1;
-const OUTSIDE: i32 = CHUNK_SIZE + 1;
-const EXPANDED_INSIDE: i32 = 2;
-const EXPANDED_OUTSIDE: i32 = CHUNK_SIZE;
 
 /// Calculates if a tile `TerrainType` should be adjusted by checking if:
 /// 1. The tile is "far enough" from the center (otherwise it cannot be an edge)

--- a/src/generation/lib/components.rs
+++ b/src/generation/lib/components.rs
@@ -1,4 +1,4 @@
-use crate::coords::point::{ChunkGrid, World};
+use crate::coords::point::{ChunkGrid, TileGrid, World};
 use crate::coords::{Coords, Point};
 use crate::generation::lib::{Chunk, LayeredPlane, Tile};
 use crate::generation::object::lib::{ObjectData, ObjectName};
@@ -20,12 +20,32 @@ pub struct ChunkComponent {
   pub layered_plane: LayeredPlane,
 }
 
-/// A component that is attached to every tile sprite that is spawned in the world. Contains the tile data
-/// and the parent entity that the tile is attached to. There's a `TileComponent` for every terrain layer.
+/// A component that is attached to every tile layer mesh that is spawned in the world. Contains the tile data
+/// and the parent entity which is a chunk. There's a `TileMeshComponent` for every terrain layer and even two if
+/// the tiles for that layer can be both animated or not (one component for each).
 #[derive(Component, Debug, Clone, Eq, Hash, PartialEq)]
-pub struct TileComponent {
-  pub tile: Tile,
-  pub parent_entity: Entity,
+pub struct TileMeshComponent {
+  parent_chunk_entity: Entity,
+  cg: Point<ChunkGrid>,
+  tiles: Vec<Tile>,
+}
+
+impl TileMeshComponent {
+  pub fn new(parent_chunk_entity: Entity, cg: Point<ChunkGrid>, tiles: Vec<Tile>) -> Self {
+    Self {
+      parent_chunk_entity,
+      cg,
+      tiles,
+    }
+  }
+
+  pub fn cg(&self) -> Point<ChunkGrid> {
+    self.cg
+  }
+
+  pub fn find_all(&self, tg: &Point<TileGrid>) -> Vec<&Tile> {
+    self.tiles.iter().filter(|t| t.coords.tile_grid == *tg).collect()
+  }
 }
 
 /// A component that is attached to every object sprite that is spawned in the world. Use for, for example,

--- a/src/generation/lib/components.rs
+++ b/src/generation/lib/components.rs
@@ -45,8 +45,8 @@ pub enum GenerationStage {
   Stage1(bool),
   /// Stage 2: Await completion of chunk generation task, then use `ChunkComponentIndex` to check if any of the chunks
   /// already exists. Return all `Chunk`s that don't exist yet, so they can be spawned.
-  Stage2(Option<Task<Vec<Chunk>>>),
   /// Stage 3: If `Chunk`s are provided and no chunk at "proposed" location exists, spawn the chunk(s) and return
+  Stage2(Task<Vec<Chunk>>),
   /// `Chunk`-`Entity` pairs. If no `Chunk`s provided, set `GenerationStage` to clean-up stage.
   Stage3(Vec<Chunk>),
   /// Stage 4: If `Chunk`-`Entity` pairs are provided and `Entity`s still exists, schedule tile spawning tasks and

--- a/src/generation/lib/components.rs
+++ b/src/generation/lib/components.rs
@@ -59,8 +59,8 @@ pub struct WorldGenerationComponent {
   pub stage_0_metadata: bool,
   pub stage_1_gen_task: Option<Task<Vec<Chunk>>>,
   pub stage_2_chunks: Vec<Chunk>,
-  pub stage_3_spawn_data: Vec<(Chunk, Vec<TileData>)>,
-  pub stage_4_spawn_data: Vec<(Chunk, Vec<TileData>)>,
+  pub stage_3_spawn_data: Vec<(Chunk, Entity)>,
+  pub stage_4_spawn_data: Vec<(Chunk, Entity)>,
   pub stage_5_object_data: Vec<Task<Vec<ObjectData>>>,
 }
 

--- a/src/generation/lib/components.rs
+++ b/src/generation/lib/components.rs
@@ -41,7 +41,7 @@ pub struct ObjectComponent {
 #[derive(Debug)]
 pub enum GenerationStage {
   /// Stage 1: Check if required metadata this `WorldGenerationComponent` exists. If no, return current stage.
-  /// Otherwise, schedule chunk generation and return the `Task`.
+  /// Otherwise, send event to clean up not-needed chunks and schedule chunk generation and return the `Task`.
   Stage1(bool),
   /// Stage 2: Await completion of chunk generation task, then use `ChunkComponentIndex` to check if any of the chunks
   /// already exists. Return all `Chunk`s that don't exist yet, so they can be spawned.
@@ -58,6 +58,7 @@ pub enum GenerationStage {
   /// Stage 6: If any object generation tasks is finished, schedule spawning of object sprites for the relevant chunk.
   /// If not, do nothing. Return all remaining `Task`s until all are finished, then proceed to next stage.
   Stage6(Vec<Task<Vec<ObjectData>>>),
+  /// Stage 7: Despawn the `WorldGenerationComponent`.
   Stage7,
   Done,
 }

--- a/src/generation/lib/components.rs
+++ b/src/generation/lib/components.rs
@@ -1,6 +1,6 @@
 use crate::coords::point::{ChunkGrid, World};
 use crate::coords::{Coords, Point};
-use crate::generation::lib::{Chunk, LayeredPlane, Tile, TileData};
+use crate::generation::lib::{Chunk, LayeredPlane, Tile};
 use crate::generation::object::lib::{ObjectData, ObjectName};
 use bevy::prelude::{Component, Entity};
 use bevy::tasks::Task;
@@ -59,8 +59,8 @@ pub struct WorldGenerationComponent {
   pub stage_0_metadata: bool,
   pub stage_1_gen_task: Option<Task<Vec<Chunk>>>,
   pub stage_2_chunks: Vec<Chunk>,
-  pub stage_3_spawn_data: Vec<(Chunk, Entity)>,
-  pub stage_4_spawn_data: Vec<(Chunk, Entity)>,
+  pub stage_3_chunks_info: Vec<(Chunk, Entity)>,
+  pub stage_4_chunks_info: Vec<(Chunk, Entity)>,
   pub stage_5_object_data: Vec<Task<Vec<ObjectData>>>,
 }
 
@@ -75,8 +75,8 @@ impl WorldGenerationComponent {
       stage_0_metadata: false,
       stage_1_gen_task: None,
       stage_2_chunks: vec![],
-      stage_3_spawn_data: vec![],
-      stage_4_spawn_data: vec![],
+      stage_3_chunks_info: vec![],
+      stage_4_chunks_info: vec![],
       stage_5_object_data: vec![],
     }
   }

--- a/src/generation/lib/components.rs
+++ b/src/generation/lib/components.rs
@@ -49,8 +49,7 @@ pub enum GenerationStage {
   Stage2(Task<Vec<Chunk>>),
   /// `Chunk`-`Entity` pairs. If no `Chunk`s provided, set `GenerationStage` to clean-up stage.
   Stage3(Vec<Chunk>),
-  // TODO: Update the below once refactored
-  /// Stage 4: If `Chunk`-`Entity` pairs are provided and `Entity`s still exists, schedule tile spawning tasks and
+  /// Stage 4: If `Chunk`-`Entity` pairs are provided and `Entity`s still exists, spawn tiles for each `Chunk` and
   /// return `Chunk`-`Entity` pairs again.
   Stage4(Vec<(Chunk, Entity)>),
   /// Stage 5: If `Chunk`-`Entity` pairs are provided and `Entity`s still exists, schedule tasks to generate object
@@ -59,7 +58,8 @@ pub enum GenerationStage {
   /// Stage 6: If any object generation tasks is finished, schedule spawning of object sprites for the relevant chunk.
   /// If not, do nothing. Return all remaining `Task`s until all are finished, then proceed to next stage.
   Stage6(Vec<Task<Vec<ObjectData>>>),
-  /// Stage 7: Despawn the `WorldGenerationComponent`.
+  /// Stage 7: Despawn the `WorldGenerationComponent` and, if necessary, fire a (second) send event to clean up
+  /// not-needed chunks.
   Stage7,
   Done,
 }

--- a/src/generation/lib/components.rs
+++ b/src/generation/lib/components.rs
@@ -59,7 +59,7 @@ pub enum GenerationStage {
   /// If not, do nothing. Return all remaining `Task`s until all are finished, then proceed to next stage.
   Stage6(Vec<Task<Vec<ObjectData>>>),
   Stage7,
-  Stage8,
+  Done,
 }
 
 impl PartialEq for GenerationStage {
@@ -72,7 +72,7 @@ impl PartialEq for GenerationStage {
       (GenerationStage::Stage5(_), GenerationStage::Stage5(_)) => true,
       (GenerationStage::Stage6(_), GenerationStage::Stage6(_)) => true,
       (GenerationStage::Stage7, GenerationStage::Stage7) => true,
-      (GenerationStage::Stage8, GenerationStage::Stage8) => true,
+      (GenerationStage::Done, GenerationStage::Done) => true,
       _ => false,
     }
   }
@@ -88,7 +88,7 @@ impl Display for GenerationStage {
       GenerationStage::Stage5(_) => write!(f, "Stage 5"),
       GenerationStage::Stage6(_) => write!(f, "Stage 6"),
       GenerationStage::Stage7 => write!(f, "Stage 7"),
-      GenerationStage::Stage8 => write!(f, "Stage 8"),
+      GenerationStage::Done => write!(f, "Done"),
     }
   }
 }

--- a/src/generation/lib/components.rs
+++ b/src/generation/lib/components.rs
@@ -49,6 +49,7 @@ pub enum GenerationStage {
   Stage2(Task<Vec<Chunk>>),
   /// `Chunk`-`Entity` pairs. If no `Chunk`s provided, set `GenerationStage` to clean-up stage.
   Stage3(Vec<Chunk>),
+  // TODO: Update the below once refactored
   /// Stage 4: If `Chunk`-`Entity` pairs are provided and `Entity`s still exists, schedule tile spawning tasks and
   /// return `Chunk`-`Entity` pairs again.
   Stage4(Vec<(Chunk, Entity)>),

--- a/src/generation/lib/layered_plane.rs
+++ b/src/generation/lib/layered_plane.rs
@@ -62,13 +62,13 @@ impl LayeredPlane {
 
   /// Returns a tuple of mutable references with the `Plane` at the specified layer and the `Plane` below it.
   pub fn get_and_below_mut(&mut self, layer: usize) -> (Option<&mut Plane>, Option<&mut Plane>) {
-    if layer == 0 {
-      return (self.planes.get_mut(layer), None);
+    match layer {
+      0 => (self.planes.get_mut(layer), None),
+      _ if layer >= self.planes.len() => (None, None),
+      _ => {
+        let (below, this_and_above) = self.planes.split_at_mut(layer);
+        (this_and_above.get_mut(0), below.get_mut(layer - 1))
+      }
     }
-    if layer >= self.planes.len() {
-      return (None, None);
-    }
-    let (below, this_and_above) = self.planes.split_at_mut(layer);
-    (this_and_above.get_mut(0), below.get_mut(layer - 1))
   }
 }

--- a/src/generation/lib/mod.rs
+++ b/src/generation/lib/mod.rs
@@ -14,9 +14,7 @@ mod tile_type;
 
 pub use crate::resources::Settings;
 pub use chunk::Chunk;
-pub use components::{
-  ChunkComponent, GenerationStage, ObjectComponent, TileComponent, WorldComponent, WorldGenerationComponent,
-};
+pub use components::*;
 pub use direction::{get_direction_points, Direction};
 pub use draft_tile::DraftTile;
 pub use layered_plane::LayeredPlane;

--- a/src/generation/lib/mod.rs
+++ b/src/generation/lib/mod.rs
@@ -9,7 +9,6 @@ mod plane;
 pub(crate) mod shared;
 mod terrain_type;
 mod tile;
-mod tile_data;
 mod tile_type;
 
 pub use crate::resources::Settings;
@@ -22,5 +21,4 @@ pub use neighbours::{NeighbourTile, NeighbourTiles};
 pub use plane::Plane;
 pub use terrain_type::TerrainType;
 pub use tile::Tile;
-pub use tile_data::TileData;
 pub use tile_type::TileType;

--- a/src/generation/lib/shared.rs
+++ b/src/generation/lib/shared.rs
@@ -1,7 +1,6 @@
 use crate::coords::point::ChunkGrid;
 use crate::coords::Point;
 use crate::generation::resources::GenerationResourcesCollection;
-use crate::resources::Settings;
 use bevy::ecs::world::CommandQueue;
 use bevy::hierarchy::DespawnRecursiveExt;
 use bevy::prelude::{Commands, Component, Entity, Query};

--- a/src/generation/lib/shared.rs
+++ b/src/generation/lib/shared.rs
@@ -17,6 +17,7 @@ pub fn thread_name() -> String {
   let thread = thread::current();
   let thread_name = thread.name().unwrap_or("Unnamed");
   let thread_id = thread.id();
+  
   format!("[{} {:?}]", thread_name, thread_id)
 }
 
@@ -35,6 +36,7 @@ pub fn get_resources_and_settings(world: &mut bevy::ecs::world::World) -> (Gener
     let (resources, settings) = system_state.get_mut(world);
     (resources.clone(), settings.clone())
   };
+  
   (resources, settings)
 }
 
@@ -45,5 +47,6 @@ pub fn get_time() -> u128 {
 pub fn calculate_seed(cg: Point<ChunkGrid>, seed: u32) -> u64 {
   let adjusted_x = cg.x as i64 + i32::MAX as i64;
   let adjusted_y = cg.y as i64 + i32::MAX as i64;
+  
   ((adjusted_x as u64) << 32) ^ (adjusted_y as u64) + seed as u64
 }

--- a/src/generation/lib/shared.rs
+++ b/src/generation/lib/shared.rs
@@ -2,10 +2,9 @@ use crate::coords::point::ChunkGrid;
 use crate::coords::Point;
 use crate::generation::resources::GenerationResourcesCollection;
 use crate::resources::Settings;
-use bevy::ecs::system::SystemState;
 use bevy::ecs::world::CommandQueue;
 use bevy::hierarchy::DespawnRecursiveExt;
-use bevy::prelude::{Commands, Component, Entity, Query, Res};
+use bevy::prelude::{Commands, Component, Entity, Query};
 use std::thread;
 use std::time::SystemTime;
 
@@ -17,7 +16,7 @@ pub fn thread_name() -> String {
   let thread = thread::current();
   let thread_name = thread.name().unwrap_or("Unnamed");
   let thread_id = thread.id();
-  
+
   format!("[{} {:?}]", thread_name, thread_id)
 }
 
@@ -30,14 +29,15 @@ pub fn process_tasks<T: CommandQueueTask + Component>(mut commands: Commands, mu
   }
 }
 
-pub fn get_resources_and_settings(world: &mut bevy::ecs::world::World) -> (GenerationResourcesCollection, Settings) {
-  let (resources, settings) = {
-    let mut system_state = SystemState::<(Res<GenerationResourcesCollection>, Res<Settings>)>::new(world);
-    let (resources, settings) = system_state.get_mut(world);
-    (resources.clone(), settings.clone())
-  };
-  
-  (resources, settings)
+pub fn get_resources_from_world(world: &mut bevy::ecs::world::World) -> GenerationResourcesCollection {
+  world
+    .get_resource::<GenerationResourcesCollection>()
+    .expect("Failed to fetch GenerationResourcesCollection")
+    .clone()
+}
+
+pub fn get_settings_from_world(world: &mut bevy::ecs::world::World) -> Settings {
+  world.get_resource::<Settings>().expect("Failed to fetch Settings").clone()
 }
 
 pub fn get_time() -> u128 {
@@ -47,6 +47,6 @@ pub fn get_time() -> u128 {
 pub fn calculate_seed(cg: Point<ChunkGrid>, seed: u32) -> u64 {
   let adjusted_x = cg.x as i64 + i32::MAX as i64;
   let adjusted_y = cg.y as i64 + i32::MAX as i64;
-  
+
   ((adjusted_x as u64) << 32) ^ (adjusted_y as u64) + seed as u64
 }

--- a/src/generation/lib/shared.rs
+++ b/src/generation/lib/shared.rs
@@ -36,10 +36,6 @@ pub fn get_resources_from_world(world: &mut bevy::ecs::world::World) -> Generati
     .clone()
 }
 
-pub fn get_settings_from_world(world: &mut bevy::ecs::world::World) -> Settings {
-  world.get_resource::<Settings>().expect("Failed to fetch Settings").clone()
-}
-
 pub fn get_time() -> u128 {
   SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis()
 }

--- a/src/generation/lib/tile_data.rs
+++ b/src/generation/lib/tile_data.rs
@@ -5,15 +5,13 @@ use bevy::reflect::Reflect;
 /// Contains the tile entity, parent chunk entity, and tile of the highest, non-empty layer of a tile.
 #[derive(Clone, Copy, Debug, Reflect)]
 pub struct TileData {
-  pub entity: Entity,
   pub chunk_entity: Entity,
   pub flat_tile: Tile,
 }
 
 impl TileData {
-  pub fn new(entity: Entity, parent_entity: Entity, tile: Tile) -> Self {
+  pub fn new(parent_entity: Entity, tile: Tile) -> Self {
     Self {
-      entity,
       chunk_entity: parent_entity,
       flat_tile: tile,
     }

--- a/src/generation/lib/tile_type.rs
+++ b/src/generation/lib/tile_type.rs
@@ -25,10 +25,6 @@ pub enum TileType {
 }
 
 impl TileType {
-  pub fn get_sprite_index(&self, index_offset: usize) -> usize {
-    get_sprite_index(self, index_offset)
-  }
-
   pub fn calculate_sprite_index(
     &self,
     terrain: &TerrainType,

--- a/src/generation/mod.rs
+++ b/src/generation/mod.rs
@@ -395,6 +395,7 @@ fn stage_6_schedule_spawning_objects(
   }
 }
 
+// TODO: Test pruning world before generating new chunks
 fn stage_7_clean_up(
   commands: &mut Commands,
   prune_world_event: &mut EventWriter<PruneWorldEvent>,

--- a/src/generation/mod.rs
+++ b/src/generation/mod.rs
@@ -173,7 +173,7 @@ fn world_generation_system(
       GenerationStage::Stage6 => s6_schedule_spawning_objects(&mut commands, &settings, &mut component),
       GenerationStage::Stage7 => s7_clean_up(&mut commands, &mut prune_world_event, entity, &mut component, &settings),
     }
-    debug!(
+    trace!(
       "World generation component {} ({}) reached stage [{:?}] which took {} ms",
       component.cg,
       entity,

--- a/src/generation/mod.rs
+++ b/src/generation/mod.rs
@@ -277,8 +277,15 @@ fn stage_4_schedule_spawning_tiles(
 ) {
   if !component.stage_3_spawn_data.is_empty() {
     let spawn_data = component.stage_3_spawn_data.remove(0);
-    world::schedule_tile_spawning_tasks(&mut commands, &settings, spawn_data.clone());
-    component.stage_4_spawn_data.push(spawn_data);
+    if commands.get_entity(spawn_data.1[0].chunk_entity).is_some() {
+      world::schedule_tile_spawning_tasks(&mut commands, &settings, spawn_data.clone());
+      component.stage_4_spawn_data.push(spawn_data);
+    } else {
+      warn!(
+        "Chunk entity {:?} at {} no longer exists (it probably has been pruned already) - skipped scheduling of tile spawning tasks...", 
+        spawn_data.1[0].chunk_entity, spawn_data.0.coords.chunk_grid
+      );
+    }
   }
   if component.stage_3_spawn_data.is_empty() {
     component.stage = GenerationStage::Stage5;

--- a/src/generation/mod.rs
+++ b/src/generation/mod.rs
@@ -401,7 +401,7 @@ fn prune_world(
   let chunks_to_despawn = calculate_chunks_to_despawn(existing_chunks, current_chunk, despawn_all_chunks);
   for chunk_entity in chunks_to_despawn.iter() {
     if let Some(entity) = commands.get_entity(*chunk_entity) {
-      entity.despawn_recursive();
+      entity.try_despawn_recursive();
     }
   }
   info!(

--- a/src/generation/mod.rs
+++ b/src/generation/mod.rs
@@ -47,7 +47,12 @@ impl Plugin for GenerationPlugin {
       .add_systems(Update, world_generation_system.run_if(in_state(GenerationState::Generating)))
       .add_systems(
         Update,
-        (regenerate_world_event, update_world_event, prune_world_event).run_if(in_state(AppState::Running)),
+        (
+          regenerate_world_event,
+          update_world_event,
+          prune_world_event.after(world_generation_system),
+        )
+          .run_if(in_state(AppState::Running)),
       )
       .add_observer(on_remove_update_world_component_trigger);
   }

--- a/src/generation/mod.rs
+++ b/src/generation/mod.rs
@@ -343,14 +343,14 @@ fn stage_4_spawn_tile_meshes(
     let mut new_chunk_entity_pairs = Vec::new();
     for (chunk, chunk_entity) in chunk_entity_pairs.drain(..) {
       if commands.get_entity(chunk_entity).is_some() {
-        world::spawn_tile_layer_meshes(
+        world::spawn_tiles(
           &mut commands,
-          &settings,
-          chunk.clone(),
           chunk_entity,
+          chunk.clone(),
+          &settings,
+          &resources,
           meshes,
           materials,
-          &resources,
         );
         new_chunk_entity_pairs.push((chunk, chunk_entity));
       } else {

--- a/src/generation/mod.rs
+++ b/src/generation/mod.rs
@@ -190,7 +190,7 @@ fn world_generation_system(
         stage_6_schedule_spawning_objects(&mut commands, &settings, generation_tasks, component_cg)
       }
       GenerationStage::Stage7 => stage_7_clean_up(&mut commands, &mut prune_world_event, &mut component, entity, &settings),
-      GenerationStage::Stage8 => GenerationStage::Stage8,
+      GenerationStage::Done => GenerationStage::Done,
     };
     trace!(
       "World generation component {} ({}) reached stage [{}] which took {} ms",
@@ -415,7 +415,7 @@ fn stage_7_clean_up(
   );
   commands.entity(entity).despawn_recursive();
 
-  GenerationStage::Stage8
+  GenerationStage::Done
 }
 
 /// Sets the `GenerationState` to `Idling` when the last `UpdateWorldComponent` has just been removed.

--- a/src/generation/mod.rs
+++ b/src/generation/mod.rs
@@ -64,7 +64,7 @@ fn initiate_world_generation_system(mut commands: Commands, mut next_state: ResM
   let cg = ORIGIN_CHUNK_GRID_SPAWN_POINT;
   debug!("Generating world with origin {} {}", w, cg);
   commands.spawn((
-    Name::new(format!("Update World Component {}", w)),
+    Name::new(format!("World Generation Component {}", w)),
     WorldGenerationComponent::new(w, cg, false, shared::get_time()),
   ));
   commands.spawn((
@@ -93,7 +93,7 @@ fn regenerate_world_event(
     debug!("Regenerating world with origin {} {}", w, cg);
     commands.entity(world).despawn_recursive();
     commands.spawn((
-      Name::new(format!("Update World Component {}", cg)),
+      Name::new(format!("World Generation Component {}", cg)),
       WorldGenerationComponent::new(w, cg, false, shared::get_time()),
     ));
     commands.spawn((
@@ -124,7 +124,7 @@ fn update_world_event(
     let new_parent_cg = Point::new_chunk_grid_from_world(new_parent_w);
     debug!("Updating world with new current chunk at {} {}", new_parent_w, new_parent_cg);
     commands.spawn((
-      Name::new(format!("Update World Component {}", new_parent_w)),
+      Name::new(format!("World Generation Component {}", new_parent_w)),
       WorldGenerationComponent::new(new_parent_w, new_parent_cg, event.is_forced_update, shared::get_time()),
     ));
     current_chunk.update(new_parent_w);
@@ -469,12 +469,13 @@ fn prune_world(
   update_world_after: bool,
 ) {
   let start_time = shared::get_time();
-  let chunks_to_despawn = calculate_chunks_to_despawn(existing_chunks, current_chunk, despawn_all_chunks);
-  for chunk_entity in chunks_to_despawn.iter() {
-    if let Some(entity) = commands.get_entity(*chunk_entity) {
-      entity.try_despawn_recursive();
-    }
-  }
+  calculate_chunks_to_despawn(existing_chunks, current_chunk, despawn_all_chunks)
+    .iter()
+    .for_each(|chunk_entity| {
+      if let Some(entity) = commands.get_entity(*chunk_entity) {
+        entity.try_despawn_recursive();
+      }
+    });
   info!(
     "World pruning (despawn_all_chunks={}, update_world_after={}) took {} ms on [{}]",
     despawn_all_chunks,

--- a/src/generation/mod.rs
+++ b/src/generation/mod.rs
@@ -328,6 +328,7 @@ fn stage_3_spawn_chunks(
   GenerationStage::Stage7
 }
 
+// TODO: Make sure that all chunks are pruned properly using this mesh rendering method
 // TODO: Fix bug that duplicates generating and spawning objects
 fn stage_4_spawn_tile_meshes(
   mut commands: &mut Commands,
@@ -412,7 +413,7 @@ fn stage_6_schedule_spawning_objects(
       if task.is_finished() {
         let object_data = block_on(poll_once(task)).expect("Failed to get object data");
         let mut rng = StdRng::seed_from_u64(shared::calculate_seed(*cg, settings.world.noise_seed));
-        object::schedule_spawning_objects(&mut commands, &settings, &mut rng, object_data);
+        object::schedule_spawning_objects(&mut commands, &settings, &mut rng, object_data, cg);
         false
       } else {
         true

--- a/src/generation/mod.rs
+++ b/src/generation/mod.rs
@@ -188,7 +188,7 @@ fn world_generation_system(
       GenerationStage::Stage3(chunks) => {
         stage_3_spawn_chunks(&mut commands, world_entity, &existing_chunks, chunks, component_cg)
       }
-      GenerationStage::Stage4(chunk_entity_pairs) => stage_4_schedule_spawning_tiles(
+      GenerationStage::Stage4(chunk_entity_pairs) => stage_4_spawn_tile_meshes(
         &mut commands,
         &settings,
         &resources,
@@ -328,7 +328,8 @@ fn stage_3_spawn_chunks(
   GenerationStage::Stage7
 }
 
-fn stage_4_schedule_spawning_tiles(
+// TODO: Fix bug that duplicates generating and spawning objects
+fn stage_4_spawn_tile_meshes(
   mut commands: &mut Commands,
   settings: &Res<Settings>,
   resources: &GenerationResourcesCollection,
@@ -341,8 +342,7 @@ fn stage_4_schedule_spawning_tiles(
     let mut new_chunk_entity_pairs = Vec::new();
     for (chunk, chunk_entity) in chunk_entity_pairs.drain(..) {
       if commands.get_entity(chunk_entity).is_some() {
-        // world::schedule_tile_spawning_tasks(&mut commands, &settings, chunk.clone(), chunk_entity);
-        world::spawn_layer_meshes(
+        world::spawn_tile_layer_meshes(
           &mut commands,
           &settings,
           chunk.clone(),

--- a/src/generation/object/lib/mod.rs
+++ b/src/generation/object/lib/mod.rs
@@ -3,6 +3,7 @@ mod connection_type;
 mod object_data;
 mod object_grid;
 mod object_name;
+pub mod tile_data;
 mod wfc_status;
 
 pub use cell::Cell;

--- a/src/generation/object/lib/object_data.rs
+++ b/src/generation/object/lib/object_data.rs
@@ -1,4 +1,4 @@
-use crate::generation::lib::TileData;
+use crate::generation::object::lib::tile_data::TileData;
 use crate::generation::object::lib::{Cell, ObjectName};
 use bevy::log::*;
 

--- a/src/generation/object/lib/object_grid.rs
+++ b/src/generation/object/lib/object_grid.rs
@@ -1,8 +1,9 @@
 use crate::constants::CHUNK_SIZE;
 use crate::coords::point::{ChunkGrid, InternalGrid};
 use crate::coords::Point;
-use crate::generation::lib::{TerrainType, TileData, TileType};
+use crate::generation::lib::{TerrainType, TileType};
 use crate::generation::object::lib::connection_type::get_connection_points;
+use crate::generation::object::lib::tile_data::TileData;
 use crate::generation::object::lib::{Cell, Connection, ObjectName};
 use crate::generation::resources::TerrainState;
 use bevy::log::*;

--- a/src/generation/object/lib/object_grid.rs
+++ b/src/generation/object/lib/object_grid.rs
@@ -165,8 +165,8 @@ fn resolve_rules(
     }
   }
 
-  debug!(
-    "Resolved {} rules for this [{:?}] tile from {:?} [{}] terrain rules and {:?} tile type rules: {:?}",
+  trace!(
+    "Resolved {} rule(s) for this [{:?}] tile from {:?} [{}] terrain rules and {:?} tile type rules: {:?}",
     resolved_rules.len(),
     tile_type,
     terrain_rules.len(),

--- a/src/generation/object/lib/tile_data.rs
+++ b/src/generation/object/lib/tile_data.rs
@@ -2,7 +2,7 @@ use crate::generation::lib::Tile;
 use bevy::prelude::Entity;
 use bevy::reflect::Reflect;
 
-/// Contains the tile entity, parent chunk entity, and tile of the highest, non-empty layer of a tile.
+/// Contains the parent chunk entity, and tile of the highest, non-empty layer of a tile.
 #[derive(Clone, Copy, Debug, Reflect)]
 pub struct TileData {
   pub chunk_entity: Entity,

--- a/src/generation/object/object_generator.rs
+++ b/src/generation/object/object_generator.rs
@@ -25,7 +25,9 @@ pub struct ObjectGeneratorPlugin;
 
 impl Plugin for ObjectGeneratorPlugin {
   fn build(&self, app: &mut App) {
-    app.add_plugins(WfcPlugin).add_systems(Update, process_async_tasks_system);
+    app
+      .add_plugins(WfcPlugin)
+      .add_systems(Update, process_object_spawn_tasks_system);
   }
 }
 
@@ -219,6 +221,6 @@ fn sprite(
   )
 }
 
-fn process_async_tasks_system(commands: Commands, object_spawn_tasks: Query<(Entity, &mut ObjectSpawnTask)>) {
+fn process_object_spawn_tasks_system(commands: Commands, object_spawn_tasks: Query<(Entity, &mut ObjectSpawnTask)>) {
   shared::process_tasks(commands, object_spawn_tasks);
 }

--- a/src/generation/object/object_generator.rs
+++ b/src/generation/object/object_generator.rs
@@ -192,6 +192,7 @@ fn sprite(
   let base_z = (tile.coords.chunk_grid.y * CHUNK_SIZE) as f32;
   let internal_z = tile.coords.internal_grid.y as f32;
   let z = 10000. - base_z + internal_z - (offset_y / TILE_SIZE as f32);
+
   (
     Name::new(format!("{} {:?} Object Sprite", tile.coords.tile_grid, object_name)),
     Sprite {

--- a/src/generation/object/object_generator.rs
+++ b/src/generation/object/object_generator.rs
@@ -122,7 +122,7 @@ fn attach_task_to_tile_entity(
           )
           .clone()
       };
-      if let Ok(mut tile_data_entity) = world.get_entity_mut(tile_data.entity) {
+      if let Ok(mut tile_data_entity) = world.get_entity_mut(tile_data.chunk_entity) {
         tile_data_entity.with_children(|parent| {
           parent.spawn(sprite(
             &tile_data.flat_tile,

--- a/src/generation/object/object_generator.rs
+++ b/src/generation/object/object_generator.rs
@@ -188,11 +188,11 @@ fn sprite(
   offset_y: f32,
   colour: Color,
 ) -> (Name, Sprite, Transform, ObjectComponent) {
-  let base_z = tile.layer as f32 + (tile.coords.chunk_grid.y * CHUNK_SIZE) as f32;
+  let base_z = (tile.coords.chunk_grid.y * CHUNK_SIZE) as f32;
   let internal_z = tile.coords.internal_grid.y as f32;
   let z = 10000. - base_z + internal_z - (offset_y / TILE_SIZE as f32);
   (
-    Name::new(format!("{:?} Object Sprite", object_name)),
+    Name::new(format!("{} {:?} Object Sprite", tile.coords.tile_grid, object_name)),
     Sprite {
       anchor: Anchor::BottomCenter,
       texture_atlas: Option::from(TextureAtlas {

--- a/src/generation/object/object_generator.rs
+++ b/src/generation/object/object_generator.rs
@@ -1,4 +1,6 @@
 use crate::constants::*;
+use crate::coords::point::ChunkGrid;
+use crate::coords::Point;
 use crate::generation::lib::shared::CommandQueueTask;
 use crate::generation::lib::{shared, Chunk, ObjectComponent, Tile};
 use crate::generation::object::lib::tile_data::TileData;
@@ -86,15 +88,11 @@ pub fn schedule_spawning_objects(
   settings: &Settings,
   mut rng: &mut StdRng,
   object_data: Vec<ObjectData>,
+  chunk_cg: &Point<ChunkGrid>,
 ) {
   let start_time = shared::get_time();
   let task_pool = AsyncComputeTaskPool::get();
   let object_data_len = object_data.len();
-  let chunk_cg = if let Some(object_data) = object_data.first() {
-    object_data.tile_data.flat_tile.coords.chunk_grid.to_string()
-  } else {
-    "cg(unknown)".to_string()
-  };
   for object in object_data {
     attach_object_spawn_task(commands, settings, &mut rng, task_pool, object);
   }

--- a/src/generation/object/object_generator.rs
+++ b/src/generation/object/object_generator.rs
@@ -11,11 +11,10 @@ use crate::resources::Settings;
 use bevy::app::{App, Plugin, Update};
 use bevy::color::{Color, Luminance};
 use bevy::core::Name;
-use bevy::ecs::system::SystemState;
 use bevy::ecs::world::CommandQueue;
 use bevy::hierarchy::{BuildChildren, ChildBuild};
 use bevy::log::*;
-use bevy::prelude::{Commands, Component, Entity, Query, Res, TextureAtlas, Transform};
+use bevy::prelude::{Commands, Component, Entity, Query, TextureAtlas, Transform};
 use bevy::sprite::{Anchor, Sprite};
 use bevy::tasks;
 use bevy::tasks::{block_on, AsyncComputeTaskPool, Task};
@@ -122,8 +121,8 @@ fn attach_task_to_tile_entity(
     let mut command_queue = CommandQueue::default();
     command_queue.push(move |world: &mut bevy::prelude::World| {
       let asset_collection = {
-        let mut system_state = SystemState::<Res<GenerationResourcesCollection>>::new(world);
-        let resources = system_state.get_mut(world);
+        let resources = shared::get_resources_from_world(world);
+
         resources
           .get_object_collection(
             tile_data.flat_tile.terrain,

--- a/src/generation/object/object_generator.rs
+++ b/src/generation/object/object_generator.rs
@@ -1,6 +1,7 @@
 use crate::constants::*;
 use crate::generation::lib::shared::CommandQueueTask;
-use crate::generation::lib::{shared, Chunk, ObjectComponent, Tile, TileData};
+use crate::generation::lib::{shared, Chunk, ObjectComponent, Tile};
+use crate::generation::object::lib::tile_data::TileData;
 use crate::generation::object::lib::ObjectName;
 use crate::generation::object::lib::{ObjectData, ObjectGrid};
 use crate::generation::object::wfc;

--- a/src/generation/object/object_generator.rs
+++ b/src/generation/object/object_generator.rs
@@ -132,8 +132,8 @@ fn attach_task_to_tile_entity(
           )
           .clone()
       };
-      if let Ok(mut tile_data_entity) = world.get_entity_mut(tile_data.chunk_entity) {
-        tile_data_entity.with_children(|parent| {
+      if let Ok(mut chunk_entity) = world.get_entity_mut(tile_data.chunk_entity) {
+        chunk_entity.with_children(|parent| {
           parent.spawn(sprite(
             &tile_data.flat_tile,
             sprite_index,
@@ -146,6 +146,7 @@ fn attach_task_to_tile_entity(
         });
       }
     });
+
     command_queue
   });
 

--- a/src/generation/object/object_generator.rs
+++ b/src/generation/object/object_generator.rs
@@ -96,7 +96,7 @@ pub fn schedule_spawning_objects(
     "cg(unknown)".to_string()
   };
   for object in object_data {
-    attach_task_to_tile_entity(commands, settings, &mut rng, task_pool, object);
+    attach_object_spawn_task(commands, settings, &mut rng, task_pool, object);
   }
   debug!(
     "Scheduled {} object spawn tasks for chunk {} in {} ms on {}",
@@ -107,7 +107,7 @@ pub fn schedule_spawning_objects(
   );
 }
 
-fn attach_task_to_tile_entity(
+fn attach_object_spawn_task(
   commands: &mut Commands,
   settings: &Settings,
   mut rng: &mut StdRng,
@@ -154,6 +154,7 @@ fn attach_task_to_tile_entity(
   commands.spawn((Name::new("Object Spawn Task"), ObjectSpawnTask(task)));
 }
 
+// TODO: Remove or make colour randomisation look better/more visible
 fn get_randomised_colour(settings: &Settings, rng: &mut StdRng, object_data: &ObjectData) -> Color {
   let base_color = Color::default();
   if object_data.is_large_sprite && settings.object.enable_colour_variations {

--- a/src/generation/object/wfc/mod.rs
+++ b/src/generation/object/wfc/mod.rs
@@ -1,4 +1,5 @@
-use crate::generation::lib::{shared, TileData};
+use crate::generation::lib::shared;
+use crate::generation::object::lib::tile_data::TileData;
 use crate::generation::object::lib::{Cell, IterationResult, ObjectData, ObjectGrid};
 use crate::resources::Settings;
 use bevy::app::{App, Plugin};

--- a/src/generation/object/wfc/mod.rs
+++ b/src/generation/object/wfc/mod.rs
@@ -24,9 +24,7 @@ pub fn determine_objects_in_grid(
   let mut snapshots = vec![];
   let mut iter_count = 1;
   let mut has_entropy = true;
-  let mut snapshot_error_count: usize = 0;
-  let mut iter_error_count: usize = 0;
-  let mut total_error_count = 0;
+  let (mut snapshot_error_count, mut iter_error_count, mut total_error_count) = (0, 0, 0);
 
   while has_entropy {
     match iterate(&mut rng, grid) {
@@ -185,7 +183,7 @@ fn log_summary(start_time: u128, snapshot_error_count: usize, total_error_count:
   match (total_error_count, snapshot_error_count) {
     (0, 0) => {
       trace!(
-        "Completed wave function collapse for {} in {} ms on [{}]",
+        "Completed wave function collapse for {} in {} ms on {}",
         grid.cg,
         shared::get_time() - start_time,
         shared::thread_name()
@@ -193,7 +191,7 @@ fn log_summary(start_time: u128, snapshot_error_count: usize, total_error_count:
     }
     (1..15, 0) => {
       debug!(
-        "Completed wave function collapse for {} (resolving {} errors) in {} ms on [{}]",
+        "Completed wave function collapse for {} (resolving {} errors) in {} ms on {}",
         grid.cg,
         total_error_count,
         shared::get_time() - start_time,
@@ -202,7 +200,7 @@ fn log_summary(start_time: u128, snapshot_error_count: usize, total_error_count:
     }
     (15.., 0) => {
       warn!(
-        "Completed wave function collapse for {} (resolving {} errors) in {} ms on [{}]",
+        "Completed wave function collapse for {} (resolving {} errors) in {} ms on {}",
         grid.cg,
         total_error_count,
         shared::get_time() - start_time,
@@ -211,7 +209,7 @@ fn log_summary(start_time: u128, snapshot_error_count: usize, total_error_count:
     }
     _ => {
       error!(
-        "Completed wave function collapse for {} (resolving {} errors and leaving {} unresolved) in {} ms on [{}]",
+        "Completed wave function collapse for {} (resolving {} errors and leaving {} unresolved) in {} ms on {}",
         grid.cg,
         total_error_count,
         snapshot_error_count,

--- a/src/generation/object/wfc/mod.rs
+++ b/src/generation/object/wfc/mod.rs
@@ -144,7 +144,7 @@ fn create_object_data(grid: &ObjectGrid, tile_data: &Vec<TileData>) -> Vec<Objec
       .filter_map(|tile_data| {
         grid
           .get_cell(&tile_data.flat_tile.coords.internal_grid)
-          .filter(|cell| cell.index != 0)
+          .filter(|cell| cell.index != 0) // Sprite index 0 is always transparent
           .map(|cell| ObjectData::from_wfc_cell(tile_data, cell))
       })
       .collect::<Vec<ObjectData>>(),

--- a/src/generation/resources/chunk_component_index.rs
+++ b/src/generation/resources/chunk_component_index.rs
@@ -32,6 +32,10 @@ impl ChunkComponentIndex {
       None
     }
   }
+
+  pub fn size(&self) -> usize {
+    self.map.len()
+  }
 }
 
 fn on_add_chunk_component_trigger(

--- a/src/generation/world/metadata_generator.rs
+++ b/src/generation/world/metadata_generator.rs
@@ -19,14 +19,14 @@ pub struct MetadataGeneratorPlugin;
 impl Plugin for MetadataGeneratorPlugin {
   fn build(&self, app: &mut App) {
     app
-      .add_systems(OnEnter(AppState::Initialising), initialise_metadata)
-      .add_systems(Update, (update_metadata, refresh_metadata_event));
+      .add_systems(OnEnter(AppState::Initialising), initialise_metadata_system)
+      .add_systems(Update, (update_metadata_system, refresh_metadata_event));
   }
 }
 
 /// This function is intended to be used to generate performance intensive metadata for the world prior to running the
 /// main loop.
-fn initialise_metadata(
+fn initialise_metadata_system(
   metadata: ResMut<Metadata>,
   current_chunk: Res<CurrentChunk>,
   settings: Res<Settings>,
@@ -39,7 +39,7 @@ fn initialise_metadata(
 /// Currently we're always regenerating the metadata for the entire grid. This is to allow changing the step size in
 /// the UI without having visual artifacts due to already generated metadata that is then incorrect. If this becomes
 /// a performance issue, we can change it but as of now, it's never taken anywhere near 1 ms.
-fn update_metadata(mut metadata: ResMut<Metadata>, current_chunk: Res<CurrentChunk>, settings: Res<Settings>) {
+fn update_metadata_system(mut metadata: ResMut<Metadata>, current_chunk: Res<CurrentChunk>, settings: Res<Settings>) {
   if metadata.current_chunk_cg == current_chunk.get_chunk_grid() {
     return;
   }

--- a/src/generation/world/mod.rs
+++ b/src/generation/world/mod.rs
@@ -15,4 +15,4 @@ impl Plugin for WorldGenerationPlugin {
   }
 }
 
-pub use crate::generation::world::world_generator::{generate_chunks, spawn_tile_layer_meshes, spawn_chunk};
+pub use crate::generation::world::world_generator::{generate_chunks, spawn_tiles, spawn_chunk};

--- a/src/generation/world/mod.rs
+++ b/src/generation/world/mod.rs
@@ -15,4 +15,4 @@ impl Plugin for WorldGenerationPlugin {
   }
 }
 
-pub use crate::generation::world::world_generator::{generate_chunks, spawn_layer_meshes, spawn_chunk};
+pub use crate::generation::world::world_generator::{generate_chunks, spawn_tile_layer_meshes, spawn_chunk};

--- a/src/generation/world/mod.rs
+++ b/src/generation/world/mod.rs
@@ -15,4 +15,4 @@ impl Plugin for WorldGenerationPlugin {
   }
 }
 
-pub use crate::generation::world::world_generator::{generate_chunks, schedule_tile_spawning_tasks, spawn_chunk};
+pub use crate::generation::world::world_generator::{generate_chunks, spawn_layer_meshes, spawn_chunk};

--- a/src/generation/world/post_processor.rs
+++ b/src/generation/world/post_processor.rs
@@ -48,7 +48,7 @@ fn clear_single_tiles_from_chunk_with_no_fill_below(layer: usize, chunk: &mut Ch
                 return Some((tile.coords.internal_grid, Some(tile_below.tile_type)));
               }
             } else if tile.terrain != TerrainType::ShallowWater {
-              // TODO: Find out if this is still happening at all and, if so, why it's happening
+              // TODO: Find out why the below happening and fix it or remove the warning if intended
               warn!(
                 "{:?} tile {:?} {:?} removed because the layer below it was missing: {:?}",
                 tile.terrain, tile.coords.tile_grid, tile.coords.internal_grid, tile

--- a/src/generation/world/world_generator.rs
+++ b/src/generation/world/world_generator.rs
@@ -3,7 +3,7 @@ use crate::constants::{ANIMATION_LENGTH, CHUNK_SIZE, DEFAULT_ANIMATION_FRAME_DUR
 use crate::coords::point::World;
 use crate::coords::Point;
 use crate::generation::lib::shared::CommandQueueTask;
-use crate::generation::lib::{shared, Chunk, ChunkComponent, TerrainType, Tile, TileComponent, TileData};
+use crate::generation::lib::{shared, Chunk, ChunkComponent, TerrainType, Tile, TileComponent};
 use crate::generation::resources::{AssetPack, Climate, GenerationResourcesCollection, Metadata};
 use crate::generation::world::post_processor;
 use crate::resources::Settings;

--- a/src/generation/world/world_generator.rs
+++ b/src/generation/world/world_generator.rs
@@ -1,8 +1,8 @@
 use crate::components::{AnimationMeshComponent, AnimationTimer};
-use crate::constants::{CHUNK_SIZE, DEFAULT_ANIMATION_FRAME_DURATION, TILE_SIZE};
+use crate::constants::*;
 use crate::coords::point::World;
 use crate::coords::Point;
-use crate::generation::lib::{shared, Chunk, ChunkComponent, TerrainType, Tile};
+use crate::generation::lib::{shared, Chunk, ChunkComponent, Plane, TerrainType, Tile};
 use crate::generation::resources::{GenerationResourcesCollection, Metadata};
 use crate::generation::world::post_processor;
 use crate::resources::Settings;
@@ -59,17 +59,17 @@ pub fn spawn_chunk(world_child_builder: &mut ChildBuilder, chunk: &Chunk) -> Ent
     .id()
 }
 
-// TODO: Make settings.general.animate_terrain_sprites work again
-pub fn spawn_tile_layer_meshes(
+pub fn spawn_tiles(
   commands: &mut Commands,
-  settings: &Settings,
-  chunk: Chunk,
   chunk_entity: Entity,
+  chunk: Chunk,
+  settings: &Settings,
+  resources: &GenerationResourcesCollection,
   meshes: &mut ResMut<Assets<Mesh>>,
   materials: &mut ResMut<Assets<ColorMaterial>>,
-  resources: &GenerationResourcesCollection,
 ) {
   let start_time = shared::get_time();
+  let is_sprite_animation_disabled = !settings.general.animate_terrain_sprites;
   for layer in 0..TerrainType::length() {
     if layer < settings.general.spawn_from_layer || layer > settings.general.spawn_up_to_layer {
       trace!(
@@ -80,30 +80,8 @@ pub fn spawn_tile_layer_meshes(
     }
 
     if let Some(plane) = chunk.layered_plane.get(layer) {
-      let mut texture_groups: HashMap<(Handle<Image>, bool, bool), Vec<&Tile>> = HashMap::new();
-      for row in plane.data.iter() {
-        for tile in row.iter().flatten() {
-          let asset_collection = resources.get_terrain_collection(tile.terrain, tile.climate);
-          let is_animated_tile_set = asset_collection.anim.is_some();
-          let is_animated_tile = asset_collection.animated_tile_types.contains(&tile.tile_type);
-          let texture = match is_animated_tile_set {
-            true => {
-              &asset_collection
-                .anim
-                .as_ref()
-                .expect("Failed to get animated asset pack from resource collection")
-                .texture
-            }
-            false => &asset_collection.stat.texture,
-          };
-          texture_groups
-            .entry((texture.clone(), is_animated_tile_set, is_animated_tile))
-            .or_default()
-            .push(tile);
-        }
-      }
-
-      for ((texture, is_animated_tile_set, is_animated_tile), tiles) in texture_groups {
+      let texture_groups = prepare_texture_groups(resources, plane);
+      for ((texture, has_animated_sprites, is_animated), tiles) in texture_groups {
         spawn_tile_mesh(
           commands,
           resources,
@@ -113,8 +91,8 @@ pub fn spawn_tile_layer_meshes(
           texture,
           layer as f32,
           chunk_entity,
-          if is_animated_tile_set { (4.0, 17.0) } else { (1.0, 17.0) },
-          is_animated_tile,
+          has_animated_sprites,
+          if is_sprite_animation_disabled { false } else { is_animated },
         );
       }
     }
@@ -128,6 +106,39 @@ pub fn spawn_tile_layer_meshes(
   );
 }
 
+/// The purpose of this function is to group tiles by their texture and whether they will be animated so that we can
+/// spawn a single mesh for each texture.
+fn prepare_texture_groups<'a>(
+  resources: &GenerationResourcesCollection,
+  plane: &'a Plane,
+) -> HashMap<(Handle<Image>, bool, bool), Vec<&'a Tile>> {
+  let mut texture_groups: HashMap<(Handle<Image>, bool, bool), Vec<&Tile>> = HashMap::new();
+  for row in plane.data.iter() {
+    for tile in row.iter().flatten() {
+      let asset_collection = resources.get_terrain_collection(tile.terrain, tile.climate);
+      let has_animated_sprites = asset_collection.anim.is_some();
+      let is_animated = asset_collection.animated_tile_types.contains(&tile.tile_type);
+      let texture = match has_animated_sprites {
+        true => {
+          &asset_collection
+            .anim
+            .as_ref()
+            .expect("Failed to get animated asset pack from resource collection")
+            .texture
+        }
+        false => &asset_collection.stat.texture,
+      };
+
+      texture_groups
+        .entry((texture.clone(), has_animated_sprites, is_animated))
+        .or_default()
+        .push(tile);
+    }
+  }
+
+  texture_groups
+}
+
 fn spawn_tile_mesh(
   commands: &mut Commands,
   resources: &GenerationResourcesCollection,
@@ -137,28 +148,77 @@ fn spawn_tile_mesh(
   texture: Handle<Image>,
   layer: f32,
   parent_entity: Entity,
-  atlas_layout_dimensions: (f32, f32),
-  is_animated_tile: bool,
+  has_animated_sprites: bool,
+  is_animated: bool,
 ) {
   let mut mesh = Mesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::default());
+  let (vertices, indices, uvs, tile_sprite_indices, sprite_sheet_columns, sprite_sheet_rows) =
+    calculate_mesh_attributes(&resources, tiles, layer, has_animated_sprites);
+
+  mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
+  mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+  mesh.insert_indices(Indices::U32(indices));
+
+  commands.entity(parent_entity).with_children(|parent| {
+    parent
+      .spawn((
+        Mesh2d(meshes.add(mesh)),
+        MeshMaterial2d(materials.add(ColorMaterial {
+          alpha_mode: AlphaMode2d::Blend,
+          texture: Some(texture),
+          ..default()
+        })),
+        Transform::from_xyz(0.0, 0.0, layer),
+        Name::new(format!("{:?} Animated Mesh", TerrainType::from(layer as usize))),
+      ))
+      .insert_if(
+        AnimationMeshComponent {
+          timer: AnimationTimer(Timer::from_seconds(
+            match TerrainType::from(layer as usize) {
+              TerrainType::ShallowWater => DEFAULT_ANIMATION_FRAME_DURATION / 2.,
+              _ => DEFAULT_ANIMATION_FRAME_DURATION,
+            },
+            TimerMode::Repeating,
+          )),
+          frame_count: 4,
+          current_frame: 0,
+          columns: sprite_sheet_columns,
+          rows: sprite_sheet_rows,
+          tile_indices: tile_sprite_indices,
+        },
+        || is_animated,
+      );
+  });
+}
+
+fn calculate_mesh_attributes(
+  resources: &&GenerationResourcesCollection,
+  tiles: Vec<&Tile>,
+  layer: f32,
+  has_animated_sprites: bool,
+) -> (Vec<[f32; 3]>, Vec<u32>, Vec<[f32; 2]>, Vec<usize>, f32, f32) {
   let mut vertices = Vec::new();
   let mut indices = Vec::new();
   let mut uvs = Vec::new();
   let mut tile_indices = Vec::new();
   let tile_size = TILE_SIZE as f32;
-  let (columns, rows) = atlas_layout_dimensions;
+  let columns = if has_animated_sprites {
+    DEFAULT_ANIMATED_TILE_SET_COLUMNS as f32
+  } else {
+    DEFAULT_STATIC_TILE_SET_COLUMNS as f32
+  };
+  let rows = TILE_SET_ROWS as f32;
 
-  // Create a vertex buffer for all tiles
   for &tile in tiles {
     let sprite_index = tile
       .tile_type
       .calculate_sprite_index(&tile.terrain, &tile.climate, &resources);
+    let base_idx = vertices.len() as u32;
 
-    // Store the tile index for animation
+    // Tile index for animation (ignored if not animated)
     tile_indices.push(sprite_index);
 
     // Calculate vertices
-    let base_idx = vertices.len() as u32;
     let tile_x = tile.coords.world.x as f32;
     let tile_y = tile.coords.world.y as f32;
     vertices.push([tile_x, tile_y, layer]); // Top-left
@@ -178,41 +238,9 @@ fn spawn_tile_mesh(
     uvs.push([u_end, v_end]); // Bottom-right
     uvs.push([u_start, v_end]); // Bottom-left
 
-    // Add indices for the tile
+    // Add indices for both triangles
     indices.extend_from_slice(&[base_idx, base_idx + 1, base_idx + 2, base_idx, base_idx + 2, base_idx + 3]);
   }
 
-  mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
-  mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
-  mesh.insert_indices(Indices::U32(indices));
-
-  let frame_duration = match TerrainType::from(layer as usize) {
-    TerrainType::ShallowWater => DEFAULT_ANIMATION_FRAME_DURATION / 2.,
-    _ => DEFAULT_ANIMATION_FRAME_DURATION,
-  };
-
-  commands.entity(parent_entity).with_children(|parent| {
-    parent
-      .spawn((
-        Mesh2d(meshes.add(mesh)),
-        MeshMaterial2d(materials.add(ColorMaterial {
-          alpha_mode: AlphaMode2d::Blend,
-          texture: Some(texture),
-          ..default()
-        })),
-        Transform::from_xyz(0.0, 0.0, layer),
-        Name::new(format!("{:?} Animated Mesh", TerrainType::from(layer as usize))),
-      ))
-      .insert_if(
-        AnimationMeshComponent {
-          timer: AnimationTimer(Timer::from_seconds(frame_duration, TimerMode::Repeating)),
-          frame_count: 4,
-          current_frame: 0,
-          columns,
-          rows,
-          tile_indices,
-        },
-        || is_animated_tile,
-      );
-  });
+  (vertices, indices, uvs, tile_indices, columns, rows)
 }

--- a/src/generation/world/world_generator.rs
+++ b/src/generation/world/world_generator.rs
@@ -21,7 +21,7 @@ pub struct WorldGeneratorPlugin;
 
 impl Plugin for WorldGeneratorPlugin {
   fn build(&self, app: &mut App) {
-    app.add_systems(Update, process_async_tasks_system);
+    app.add_systems(Update, process_tile_spawn_tasks_system);
   }
 }
 
@@ -127,21 +127,6 @@ fn attach_sprite_spawning_task_to_chunk_entity(
   parent.spawn((Name::new("Tile Spawn Task"), TileSpawnTask(task)));
 }
 
-fn resolve_asset_pack<'a>(tile: &Tile, resources: &'a GenerationResourcesCollection) -> (bool, &'a AssetPack) {
-  let asset_collection = resources.get_terrain_collection(tile.terrain, tile.climate);
-  if asset_collection.animated_tile_types.contains(&tile.tile_type) {
-    (
-      true,
-      &asset_collection
-        .anim
-        .as_ref()
-        .expect("Failed to get animated asset pack from resource collection"),
-    )
-  } else {
-    (false, &asset_collection.stat)
-  }
-}
-
 fn spawn_tile(
   parent_entity: Entity,
   tile: &Tile,
@@ -162,6 +147,21 @@ fn spawn_tile(
     }
   } else {
     parent.spawn(static_terrain_sprite(&tile, parent_entity, &resources));
+  }
+}
+
+fn resolve_asset_pack<'a>(tile: &Tile, resources: &'a GenerationResourcesCollection) -> (bool, &'a AssetPack) {
+  let asset_collection = resources.get_terrain_collection(tile.terrain, tile.climate);
+  if asset_collection.animated_tile_types.contains(&tile.tile_type) {
+    (
+      true,
+      &asset_collection
+        .anim
+        .as_ref()
+        .expect("Failed to get animated asset pack from resource collection"),
+    )
+  } else {
+    (false, &asset_collection.stat)
   }
 }
 
@@ -284,6 +284,6 @@ fn animated_terrain_sprite(
   )
 }
 
-fn process_async_tasks_system(commands: Commands, tile_spawn_tasks: Query<(Entity, &mut TileSpawnTask)>) {
+fn process_tile_spawn_tasks_system(commands: Commands, tile_spawn_tasks: Query<(Entity, &mut TileSpawnTask)>) {
   shared::process_tasks(commands, tile_spawn_tasks);
 }

--- a/src/generation/world/world_generator.rs
+++ b/src/generation/world/world_generator.rs
@@ -169,7 +169,7 @@ fn placeholder_sprite(
   resources: &GenerationResourcesCollection,
 ) -> (Name, Sprite, Transform, TileComponent, Visibility) {
   (
-    Name::new(format!("Placeholder {:?} Sprite", tile.terrain)),
+    Name::new(format!("{} Placeholder {:?} Sprite", tile.coords.tile_grid, tile.terrain)),
     Sprite {
       anchor: Anchor::TopLeft,
       texture_atlas: Some(TextureAtlas {
@@ -194,7 +194,10 @@ fn static_terrain_sprite(
   resources: &GenerationResourcesCollection,
 ) -> (Name, Transform, Sprite, TileComponent, Visibility) {
   (
-    Name::new(format!("{:?} {:?} Sprite", tile.tile_type, tile.terrain)),
+    Name::new(format!(
+      "{} {:?} {:?} Sprite",
+      tile.coords.tile_grid, tile.tile_type, tile.terrain
+    )),
     Transform::from_xyz(tile.coords.world.x as f32, tile.coords.world.y as f32, tile.layer as f32),
     Sprite {
       anchor: Anchor::TopLeft,
@@ -252,7 +255,10 @@ fn animated_terrain_sprite(
     _ => DEFAULT_ANIMATION_FRAME_DURATION,
   };
   (
-    Name::new(format!("{:?} {:?} Sprite (Animated)", tile.tile_type, tile.terrain)),
+    Name::new(format!(
+      "{} {:?} {:?} Sprite (Animated)",
+      tile.coords.tile_grid, tile.tile_type, tile.terrain
+    )),
     Transform::from_xyz(tile.coords.world.x as f32, tile.coords.world.y as f32, tile.layer as f32),
     Sprite {
       anchor: Anchor::TopLeft,

--- a/src/generation/world/world_generator.rs
+++ b/src/generation/world/world_generator.rs
@@ -44,7 +44,7 @@ pub fn generate_chunks(spawn_points: Vec<Point<World>>, metadata: Metadata, sett
     chunks.push(chunk);
   }
   debug!(
-    "Generated {} chunks in {} ms on [{}]",
+    "Generated {} chunks in {} ms on {}",
     chunks.len(),
     shared::get_time() - start_time,
     shared::thread_name()
@@ -97,7 +97,7 @@ pub fn schedule_tile_spawning_tasks(commands: &mut Commands, settings: &Settings
     }
   }
   debug!(
-    "Scheduled spawning tiles for chunk {} in {} ms on [{}]",
+    "Scheduled spawning tiles for chunk {} in {} ms on {}",
     chunk.coords.chunk_grid,
     shared::get_time() - start_time,
     shared::thread_name()

--- a/src/generation/world/world_generator.rs
+++ b/src/generation/world/world_generator.rs
@@ -1,40 +1,24 @@
-use crate::components::{AnimationComponent, AnimationTimer};
-use crate::constants::{ANIMATION_LENGTH, CHUNK_SIZE, DEFAULT_ANIMATION_FRAME_DURATION, TERRAIN_TYPE_ERROR, TILE_SIZE};
+use crate::constants::{CHUNK_SIZE, TILE_SIZE};
 use crate::coords::point::World;
 use crate::coords::Point;
-use crate::generation::lib::shared::CommandQueueTask;
-use crate::generation::lib::{shared, Chunk, ChunkComponent, TerrainType, Tile, TileComponent};
-use crate::generation::resources::{AssetPack, Climate, GenerationResourcesCollection, Metadata};
+use crate::generation::lib::{shared, Chunk, ChunkComponent, TerrainType, Tile};
+use crate::generation::resources::{GenerationResourcesCollection, Metadata};
 use crate::generation::world::post_processor;
 use crate::resources::Settings;
-use bevy::app::{App, Plugin, Update};
+use bevy::app::{App, Plugin};
 use bevy::asset::RenderAssetUsages;
 use bevy::core::Name;
-use bevy::ecs::world::CommandQueue;
-use bevy::hierarchy::{BuildChildren, ChildBuild, ChildBuilder, WorldChildBuilder};
+use bevy::hierarchy::{BuildChildren, ChildBuild, ChildBuilder};
 use bevy::log::*;
 use bevy::prelude::*;
 use bevy::render::mesh::{Indices, PrimitiveTopology};
-use bevy::sprite::{AlphaMode2d, Anchor};
-use bevy::tasks;
-use bevy::tasks::{block_on, AsyncComputeTaskPool, Task};
+use bevy::sprite::AlphaMode2d;
 use std::collections::HashMap;
 
 pub struct WorldGeneratorPlugin;
 
 impl Plugin for WorldGeneratorPlugin {
-  fn build(&self, app: &mut App) {
-    app.add_systems(Update, process_tile_spawn_tasks_system);
-  }
-}
-
-#[derive(Component)]
-struct TileSpawnTask(Task<CommandQueue>);
-
-impl CommandQueueTask for TileSpawnTask {
-  fn poll_once(&mut self) -> Option<CommandQueue> {
-    block_on(tasks::poll_once(&mut self.0))
-  }
+  fn build(&self, _app: &mut App) {}
 }
 
 // TODO: Add tiles and use this struct for debugging
@@ -81,40 +65,8 @@ pub fn spawn_chunk(world_child_builder: &mut ChildBuilder, chunk: &Chunk) -> Ent
     .id()
 }
 
-// pub fn schedule_tile_spawning_tasks(commands: &mut Commands, settings: &Settings, chunk: Chunk, chunk_entity: Entity) {
-//   let start_time = shared::get_time();
-//   let task_pool = AsyncComputeTaskPool::get();
-//
-//   for layer in 0..TerrainType::length() {
-//     if layer < settings.general.spawn_from_layer || layer > settings.general.spawn_up_to_layer {
-//       trace!(
-//         "Skipped spawning [{:?}] tiles because it's disabled",
-//         TerrainType::from(layer)
-//       );
-//       continue;
-//     }
-//     if let Some(mut parent_chunk_entity) = commands.get_entity(chunk_entity) {
-//       if let Some(plane) = chunk.layered_plane.get(layer) {
-//         plane.data.iter().flatten().for_each(|tile| {
-//           if let Some(tile) = tile {
-//             let parent_chunk_entity_id = parent_chunk_entity.id();
-//             parent_chunk_entity.with_children(|parent| {
-//               attach_sprite_spawning_task_to_chunk_entity(task_pool, parent, parent_chunk_entity_id, tile.clone());
-//             });
-//           }
-//         });
-//       }
-//     }
-//   }
-//   debug!(
-//     "Scheduled spawning tiles for chunk {} in {} ms on {}",
-//     chunk.coords.chunk_grid,
-//     shared::get_time() - start_time,
-//     shared::thread_name()
-//   );
-// }
-
-pub fn spawn_layer_meshes(
+// TODO: Make settings.general.animate_terrain_sprites work again
+pub fn spawn_tile_layer_meshes(
   commands: &mut Commands,
   settings: &Settings,
   chunk: Chunk,
@@ -124,8 +76,6 @@ pub fn spawn_layer_meshes(
   resources: &GenerationResourcesCollection,
 ) {
   let start_time = shared::get_time();
-
-  // Process each terrain layer separately
   for layer in 0..TerrainType::length() {
     if layer < settings.general.spawn_from_layer || layer > settings.general.spawn_up_to_layer {
       trace!(
@@ -136,46 +86,37 @@ pub fn spawn_layer_meshes(
     }
 
     if let Some(plane) = chunk.layered_plane.get(layer) {
-      // Group tiles by their texture/material to minimize draw calls
-      let mut texture_groups: HashMap<(Handle<Image>, Handle<TextureAtlasLayout>, bool), Vec<&Tile>> = HashMap::new();
-
-      // Collect and group tiles by texture and animation status
+      let mut texture_groups: HashMap<(Handle<Image>, bool), Vec<&Tile>> = HashMap::new();
       for row in plane.data.iter() {
         for tile in row.iter().flatten() {
-          let (is_animated, asset_pack) = resolve_asset_pack(tile, resources);
-          let texture = asset_pack.texture.clone();
-          let layout = asset_pack.texture_atlas_layout.clone();
-          texture_groups.entry((texture, layout, is_animated)).or_default().push(tile);
+          let asset_collection = resources.get_terrain_collection(tile.terrain, tile.climate);
+          let is_animated = asset_collection.anim.is_some();
+          let texture = match is_animated {
+            true => {
+              &asset_collection
+                .anim
+                .as_ref()
+                .expect("Failed to get animated asset pack from resource collection")
+                .texture
+            }
+            false => &asset_collection.stat.texture,
+          };
+          texture_groups.entry((texture.clone(), is_animated)).or_default().push(tile);
         }
       }
 
-      for ((texture, layout, is_animated), tiles) in texture_groups {
-        // if is_animated && settings.general.animate_terrain_sprites {
-        // For animated tiles, create an animated mesh
-        // spawn_animated_mesh(
-        //   commands,
-        //   meshes,
-        //   materials,
-        //   tiles,
-        //   texture,
-        //   layout,
-        //   layer as f32,
-        //   chunk_entity,
-        // );
-        // } else {
-        // For static tiles, create a static mesh
-        spawn_static_mesh(
+      for ((texture, is_animated), tiles) in texture_groups {
+        spawn_tile_mesh(
           commands,
           resources,
           meshes,
           materials,
           tiles,
           texture,
-          layout,
           layer as f32,
           chunk_entity,
+          if is_animated { (4.0, 17.0) } else { (1.0, 17.0) },
         );
-        // }
       }
     }
   }
@@ -188,25 +129,23 @@ pub fn spawn_layer_meshes(
   );
 }
 
-fn spawn_static_mesh(
+fn spawn_tile_mesh(
   commands: &mut Commands,
   resources: &GenerationResourcesCollection,
   meshes: &mut ResMut<Assets<Mesh>>,
   materials: &mut ResMut<Assets<ColorMaterial>>,
   tiles: Vec<&Tile>,
   texture: Handle<Image>,
-  layout: Handle<TextureAtlasLayout>,
-  z_layer: f32,
+  layer: f32,
   parent_entity: Entity,
+  atlas_layout_dimensions: (f32, f32),
 ) {
-  // Create mesh
   let mut mesh = Mesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::default());
   let mut vertices = Vec::new();
   let mut indices = Vec::new();
   let mut uvs = Vec::new();
   let tile_size = TILE_SIZE as f32;
-  let columns = 4.0;
-  let rows = 16.0;
+  let (columns, rows) = atlas_layout_dimensions;
 
   // Create a vertex buffer for all tiles
   for &tile in tiles {
@@ -214,242 +153,49 @@ fn spawn_static_mesh(
       .tile_type
       .calculate_sprite_index(&tile.terrain, &tile.climate, &resources);
 
-    // Calculate UV coordinates based on sprite index and atlas layout
+    // Calculate vertices
+    let base_idx = vertices.len() as u32;
+    let tile_x = tile.coords.world.x as f32;
+    let tile_y = tile.coords.world.y as f32;
+    vertices.push([tile_x, tile_y, layer]); // Top-left
+    vertices.push([tile_x + tile_size, tile_y, layer]); // Top-right
+    vertices.push([tile_x + tile_size, tile_y - tile_size, layer]); // Bottom-right
+    vertices.push([tile_x, tile_y - tile_size, layer]); // Bottom-left
+
+    // Calculate UVs
     let sprite_col = sprite_index as f32 % columns;
     let sprite_row = (sprite_index as f32 / columns).floor();
-
-    // Calculate normalized UV coordinates (0.0 to 1.0)
     let u_start = sprite_col / columns;
     let u_end = (sprite_col + 1.0) / columns;
     let v_start = sprite_row / rows;
     let v_end = (sprite_row + 1.0) / rows;
-
-    // Calculate base index for this tile
-    let base_idx = vertices.len() as u32;
-
-    // Add vertices
-    let tile_x = tile.coords.world.x as f32;
-    let tile_y = tile.coords.world.y as f32;
-    vertices.push([tile_x, tile_y, z_layer]);                         // Top-left
-    vertices.push([tile_x + tile_size, tile_y, z_layer]);             // Top-right
-    vertices.push([tile_x + tile_size, tile_y - tile_size, z_layer]); // Bottom-right
-    vertices.push([tile_x, tile_y - tile_size, z_layer]);             // Bottom-left
-
-    // Add UVs for each vertex
     uvs.push([u_start, v_start]); // Top-left
-    uvs.push([u_end, v_start]);   // Top-right
-    uvs.push([u_end, v_end]);     // Bottom-right
-    uvs.push([u_start, v_end]);   // Bottom-left
+    uvs.push([u_end, v_start]); // Top-right
+    uvs.push([u_end, v_end]); // Bottom-right
+    uvs.push([u_start, v_end]); // Bottom-left
 
-    indices.extend_from_slice(&[
-      base_idx, base_idx + 1, base_idx + 2,
-      base_idx, base_idx + 2, base_idx + 3
-    ]);
+    // Add indices for the tile
+    indices.extend_from_slice(&[base_idx, base_idx + 1, base_idx + 2, base_idx, base_idx + 2, base_idx + 3]);
   }
 
   mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
   mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
-  // mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
   mesh.insert_indices(Indices::U32(indices));
 
   commands.entity(parent_entity).with_children(|parent| {
     parent.spawn((
       Mesh2d(meshes.add(mesh)),
       MeshMaterial2d(materials.add(ColorMaterial {
-        color: Color::WHITE,
         alpha_mode: AlphaMode2d::Blend,
         texture: Some(texture),
+        ..default()
       })),
-      Transform::from_xyz(0.0, 0.0, z_layer),
-      Name::new(format!("Layer {} Mesh", z_layer)),
+      Transform::from_xyz(0.0, 0.0, layer),
+      Name::new(format!("{:?} Tile Mesh", TerrainType::from(layer as usize))),
       TileMeshComponent {
         parent_entity,
         is_animated: false,
       },
     ));
   });
-}
-
-fn attach_sprite_spawning_task_to_chunk_entity(
-  task_pool: &AsyncComputeTaskPool,
-  parent: &mut ChildBuilder,
-  chunk_entity: Entity,
-  tile: Tile,
-) {
-  let task = task_pool.spawn(async move {
-    let mut command_queue = CommandQueue::default();
-    command_queue.push(move |world: &mut bevy::prelude::World| {
-      let resources = shared::get_resources_from_world(world);
-      let settings = shared::get_settings_from_world(world);
-      if let Ok(mut parent_chunk_entity) = world.get_entity_mut(chunk_entity) {
-        parent_chunk_entity.with_children(|parent| {
-          spawn_tile(chunk_entity, &tile, &resources, settings, parent);
-        });
-      }
-    });
-
-    command_queue
-  });
-  parent.spawn((Name::new("Tile Spawn Task"), TileSpawnTask(task)));
-}
-
-fn spawn_tile(
-  parent_entity: Entity,
-  tile: &Tile,
-  resources: &GenerationResourcesCollection,
-  settings: Settings,
-  parent: &mut WorldChildBuilder,
-) {
-  if !settings.general.draw_terrain_sprites {
-    parent.spawn(placeholder_sprite(&tile, parent_entity, &resources));
-    return;
-  }
-  if settings.general.animate_terrain_sprites {
-    let (is_animated_tile, anim_asset_pack) = resolve_asset_pack(&tile, &resources);
-    if is_animated_tile {
-      parent.spawn(animated_terrain_sprite(&tile, parent_entity, &anim_asset_pack));
-    } else {
-      parent.spawn(static_terrain_sprite(&tile, parent_entity, &resources));
-    }
-  } else {
-    parent.spawn(static_terrain_sprite(&tile, parent_entity, &resources));
-  }
-}
-
-fn resolve_asset_pack<'a>(tile: &Tile, resources: &'a GenerationResourcesCollection) -> (bool, &'a AssetPack) {
-  let asset_collection = resources.get_terrain_collection(tile.terrain, tile.climate);
-  if asset_collection.animated_tile_types.contains(&tile.tile_type) {
-    (
-      true,
-      &asset_collection
-        .anim
-        .as_ref()
-        .expect("Failed to get animated asset pack from resource collection"),
-    )
-  } else {
-    (false, &asset_collection.stat)
-  }
-}
-
-fn placeholder_sprite(
-  tile: &Tile,
-  chunk: Entity,
-  resources: &GenerationResourcesCollection,
-) -> (Name, Sprite, Transform, TileComponent, Visibility) {
-  (
-    Name::new(format!("{} Placeholder {:?} Sprite", tile.coords.tile_grid, tile.terrain)),
-    Sprite {
-      anchor: Anchor::TopLeft,
-      texture_atlas: Some(TextureAtlas {
-        layout: resources.placeholder.texture_atlas_layout.clone(),
-        index: tile.terrain as usize,
-      }),
-      image: resources.placeholder.texture.clone(),
-      ..Default::default()
-    },
-    Transform::from_xyz(tile.coords.world.x as f32, tile.coords.world.y as f32, tile.layer as f32),
-    TileComponent {
-      tile: tile.clone(),
-      parent_entity: chunk,
-    },
-    Visibility::default(),
-  )
-}
-
-fn static_terrain_sprite(
-  tile: &Tile,
-  chunk: Entity,
-  resources: &GenerationResourcesCollection,
-) -> (Name, Transform, Sprite, TileComponent, Visibility) {
-  (
-    Name::new(format!(
-      "{} {:?} {:?} Sprite",
-      tile.coords.tile_grid, tile.tile_type, tile.terrain
-    )),
-    Transform::from_xyz(tile.coords.world.x as f32, tile.coords.world.y as f32, tile.layer as f32),
-    Sprite {
-      anchor: Anchor::TopLeft,
-      texture_atlas: Some(TextureAtlas {
-        layout: match (tile.terrain, tile.climate) {
-          (TerrainType::DeepWater, _) => resources.deep_water.stat.texture_atlas_layout.clone(),
-          (TerrainType::ShallowWater, _) => resources.shallow_water.stat.texture_atlas_layout.clone(),
-          (TerrainType::Land1, Climate::Dry) => resources.land_dry_l1.stat.texture_atlas_layout.clone(),
-          (TerrainType::Land1, Climate::Moderate) => resources.land_moderate_l1.stat.texture_atlas_layout.clone(),
-          (TerrainType::Land1, Climate::Humid) => resources.land_humid_l1.stat.texture_atlas_layout.clone(),
-          (TerrainType::Land2, Climate::Dry) => resources.land_dry_l2.stat.texture_atlas_layout.clone(),
-          (TerrainType::Land2, Climate::Moderate) => resources.land_moderate_l2.stat.texture_atlas_layout.clone(),
-          (TerrainType::Land2, Climate::Humid) => resources.land_humid_l2.stat.texture_atlas_layout.clone(),
-          (TerrainType::Land3, Climate::Dry) => resources.land_dry_l3.stat.texture_atlas_layout.clone(),
-          (TerrainType::Land3, Climate::Moderate) => resources.land_moderate_l3.stat.texture_atlas_layout.clone(),
-          (TerrainType::Land3, Climate::Humid) => resources.land_humid_l3.stat.texture_atlas_layout.clone(),
-          (TerrainType::Any, _) => panic!("{}", TERRAIN_TYPE_ERROR),
-        },
-        index: tile
-          .tile_type
-          .calculate_sprite_index(&tile.terrain, &tile.climate, &resources),
-      }),
-      image: match (tile.terrain, tile.climate) {
-        (TerrainType::DeepWater, _) => resources.deep_water.stat.texture.clone(),
-        (TerrainType::ShallowWater, _) => resources.shallow_water.stat.texture.clone(),
-        (TerrainType::Land1, Climate::Dry) => resources.land_dry_l1.stat.texture.clone(),
-        (TerrainType::Land1, Climate::Moderate) => resources.land_moderate_l1.stat.texture.clone(),
-        (TerrainType::Land1, Climate::Humid) => resources.land_humid_l1.stat.texture.clone(),
-        (TerrainType::Land2, Climate::Dry) => resources.land_dry_l2.stat.texture.clone(),
-        (TerrainType::Land2, Climate::Moderate) => resources.land_moderate_l2.stat.texture.clone(),
-        (TerrainType::Land2, Climate::Humid) => resources.land_humid_l2.stat.texture.clone(),
-        (TerrainType::Land3, Climate::Dry) => resources.land_dry_l3.stat.texture.clone(),
-        (TerrainType::Land3, Climate::Moderate) => resources.land_moderate_l3.stat.texture.clone(),
-        (TerrainType::Land3, Climate::Humid) => resources.land_humid_l3.stat.texture.clone(),
-        (TerrainType::Any, _) => panic!("{}", TERRAIN_TYPE_ERROR),
-      },
-      ..Default::default()
-    },
-    TileComponent {
-      tile: tile.clone(),
-      parent_entity: chunk,
-    },
-    Visibility::default(),
-  )
-}
-
-fn animated_terrain_sprite(
-  tile: &Tile,
-  chunk: Entity,
-  asset_pack: &AssetPack,
-) -> (Name, Transform, Sprite, TileComponent, AnimationComponent, Visibility) {
-  let index = tile.tile_type.get_sprite_index(asset_pack.index_offset);
-  let frame_duration = match tile.terrain {
-    TerrainType::ShallowWater => DEFAULT_ANIMATION_FRAME_DURATION / 2.,
-    _ => DEFAULT_ANIMATION_FRAME_DURATION,
-  };
-  (
-    Name::new(format!(
-      "{} {:?} {:?} Sprite (Animated)",
-      tile.coords.tile_grid, tile.tile_type, tile.terrain
-    )),
-    Transform::from_xyz(tile.coords.world.x as f32, tile.coords.world.y as f32, tile.layer as f32),
-    Sprite {
-      anchor: Anchor::TopLeft,
-      texture_atlas: Some(TextureAtlas {
-        layout: asset_pack.texture_atlas_layout.clone(),
-        index,
-      }),
-      image: asset_pack.texture.clone(),
-      ..Default::default()
-    },
-    TileComponent {
-      tile: tile.clone(),
-      parent_entity: chunk,
-    },
-    AnimationComponent {
-      index_first: index,
-      index_last: index + ANIMATION_LENGTH - 1,
-      timer: AnimationTimer(Timer::from_seconds(frame_duration, TimerMode::Repeating)),
-    },
-    Visibility::default(),
-  )
-}
-
-fn process_tile_spawn_tasks_system(commands: Commands, tile_spawn_tasks: Query<(Entity, &mut TileSpawnTask)>) {
-  shared::process_tasks(commands, tile_spawn_tasks);
 }

--- a/src/generation/world/world_generator.rs
+++ b/src/generation/world/world_generator.rs
@@ -71,10 +71,9 @@ pub fn spawn_chunk(world_child_builder: &mut ChildBuilder, chunk: &Chunk) -> Ent
     .id()
 }
 
-pub fn schedule_tile_spawning_tasks(commands: &mut Commands, settings: &Settings, spawn_data: (Chunk, Entity)) {
+pub fn schedule_tile_spawning_tasks(commands: &mut Commands, settings: &Settings, chunk: Chunk, chunk_entity: Entity) {
   let start_time = shared::get_time();
   let task_pool = AsyncComputeTaskPool::get();
-  let (chunk, chunk_entity) = spawn_data;
 
   for layer in 0..TerrainType::length() {
     if layer < settings.general.spawn_from_layer || layer > settings.general.spawn_up_to_layer {

--- a/src/generation/world/world_generator.rs
+++ b/src/generation/world/world_generator.rs
@@ -2,7 +2,7 @@ use crate::components::{AnimationMeshComponent, AnimationTimer};
 use crate::constants::*;
 use crate::coords::point::World;
 use crate::coords::Point;
-use crate::generation::lib::{shared, Chunk, ChunkComponent, Plane, TerrainType, Tile};
+use crate::generation::lib::{shared, Chunk, ChunkComponent, Plane, TerrainType, Tile, TileMeshComponent};
 use crate::generation::resources::{GenerationResourcesCollection, Metadata};
 use crate::generation::world::post_processor;
 use crate::resources::Settings;
@@ -152,6 +152,8 @@ fn spawn_tile_mesh(
   is_animated: bool,
 ) {
   let mut mesh = Mesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::default());
+  let tiles_cloned = tiles.clone();
+  let cg = tiles[0].coords.chunk_grid;
   let (vertices, indices, uvs, tile_sprite_indices, sprite_sheet_columns, sprite_sheet_rows) =
     calculate_mesh_attributes(&resources, tiles, layer, has_animated_sprites);
 
@@ -170,6 +172,7 @@ fn spawn_tile_mesh(
         })),
         Transform::from_xyz(0.0, 0.0, layer),
         Name::new(format!("{:?} Animated Mesh", TerrainType::from(layer as usize))),
+        TileMeshComponent::new(parent_entity, cg, tiles_cloned.into_iter().copied().collect()),
       ))
       .insert_if(
         AnimationMeshComponent {

--- a/src/generation/world/world_generator.rs
+++ b/src/generation/world/world_generator.rs
@@ -120,6 +120,7 @@ fn attach_task_to_tile_entity(
         });
       }
     });
+    
     command_queue
   });
   parent.spawn((Name::new("Tile Spawn Task"), TileSpawnTask(task)));

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,6 @@ use bevy::window::{PresentMode, WindowResolution};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_inspector_egui::DefaultInspectorConfigPlugin;
 use bevy_pancam::PanCamPlugin;
-use iyes_perf_ui::PerfUiPlugin;
 
 fn main() {
   App::new()
@@ -56,7 +55,6 @@ fn main() {
         .build(),
     )
     .add_plugins(PanCamPlugin::default())
-    .add_plugins(PerfUiPlugin)
     .add_plugins((
       CameraPlugin,
       AppStatePlugin,

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use bevy::window::{PresentMode, WindowResolution};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_inspector_egui::DefaultInspectorConfigPlugin;
 use bevy_pancam::PanCamPlugin;
+use iyes_perf_ui::PerfUiPlugin;
 
 fn main() {
   App::new()
@@ -55,6 +56,7 @@ fn main() {
         .build(),
     )
     .add_plugins(PanCamPlugin::default())
+    .add_plugins(PerfUiPlugin)
     .add_plugins((
       CameraPlugin,
       AppStatePlugin,

--- a/src/ui/diagnostics.rs
+++ b/src/ui/diagnostics.rs
@@ -1,7 +1,7 @@
 use crate::events::ToggleDebugInfo;
 use bevy::app::{App, Plugin};
-use bevy::diagnostic::FrameTimeDiagnosticsPlugin;
 use bevy::prelude::*;
+use iyes_perf_ui::PerfUiPlugin;
 use iyes_perf_ui::prelude::{
   PerfUiEntryCpuUsage, PerfUiEntryEntityCount, PerfUiEntryFPS, PerfUiEntryFPSWorst, PerfUiEntryFrameTime,
   PerfUiEntryFrameTimeWorst, PerfUiEntryMemUsage, PerfUiEntryRenderCpuTime, PerfUiEntryRenderGpuTime, PerfUiRoot,
@@ -13,7 +13,8 @@ pub struct DiagnosticsUiPlugin;
 impl Plugin for DiagnosticsUiPlugin {
   fn build(&self, app: &mut App) {
     app
-      .add_plugins(FrameTimeDiagnosticsPlugin::default())
+      .add_plugins(PerfUiPlugin)
+      .add_plugins(bevy::diagnostic::FrameTimeDiagnosticsPlugin::default())
       .add_plugins(bevy::diagnostic::EntityCountDiagnosticsPlugin)
       .add_plugins(bevy::diagnostic::SystemInformationDiagnosticsPlugin)
       .add_plugins(bevy::render::diagnostic::RenderDiagnosticsPlugin)

--- a/src/ui/diagnostics.rs
+++ b/src/ui/diagnostics.rs
@@ -1,10 +1,12 @@
-use crate::constants::*;
 use crate::events::ToggleDebugInfo;
-use crate::resources::Settings;
-use bevy::app::{App, Plugin, Update};
-use bevy::diagnostic::DiagnosticsStore;
+use bevy::app::{App, Plugin};
 use bevy::diagnostic::FrameTimeDiagnosticsPlugin;
 use bevy::prelude::*;
+use iyes_perf_ui::prelude::{
+  PerfUiEntryCpuUsage, PerfUiEntryEntityCount, PerfUiEntryFPS, PerfUiEntryFPSWorst, PerfUiEntryFrameTime,
+  PerfUiEntryFrameTimeWorst, PerfUiEntryMemUsage, PerfUiEntryRenderCpuTime, PerfUiEntryRenderGpuTime, PerfUiRoot,
+  PerfUiWidgetBar,
+};
 
 pub struct DiagnosticsUiPlugin;
 
@@ -12,64 +14,35 @@ impl Plugin for DiagnosticsUiPlugin {
   fn build(&self, app: &mut App) {
     app
       .add_plugins(FrameTimeDiagnosticsPlugin::default())
-      .add_systems(Startup, create_fps_counter_system)
-      .add_systems(Update, (update_fps_system, toggle_fps_counter_event));
+      .add_plugins(bevy::diagnostic::EntityCountDiagnosticsPlugin)
+      .add_plugins(bevy::diagnostic::SystemInformationDiagnosticsPlugin)
+      .add_plugins(bevy::render::diagnostic::RenderDiagnosticsPlugin)
+      .add_systems(Startup, add_perf_ui)
+      .add_systems(Update, toggle_ui.before(iyes_perf_ui::PerfUiSet::Setup));
   }
 }
 
-#[derive(Component)]
-struct FpsUiRoot;
-
-#[derive(Component)]
-struct FpsText;
-
-fn create_fps_counter_system(mut commands: Commands) {
-  commands
-    .spawn((
-      Name::new("FPS Counter"),
-      FpsUiRoot,
-      Node {
-        position_type: PositionType::Absolute,
-        right: Val::Percent(1.),
-        top: Val::Percent(1.),
-        bottom: Val::Auto,
-        left: Val::Auto,
-        padding: UiRect::all(Val::Px(4.0)),
-        margin: UiRect::all(Val::Px(1.0)),
-        ..Default::default()
-      },
-      // BackgroundColor(VERY_DARK.with_alpha(0.5)),
-      Text::new("FPS: "),
-      TextColor(LIGHT),
-    ))
-    .with_child((TextSpan::new("N/A"), FpsText, TextColor(LIGHT)));
+fn add_perf_ui(mut commands: Commands) {
+  commands.spawn((
+    PerfUiWidgetBar::new(PerfUiEntryFPS::default()),
+    PerfUiWidgetBar::new(PerfUiEntryFPSWorst::default()),
+    PerfUiEntryFrameTime::default(),
+    PerfUiEntryFrameTimeWorst::default(),
+    PerfUiEntryRenderCpuTime::default(),
+    PerfUiEntryRenderGpuTime::default(),
+    PerfUiWidgetBar::new(PerfUiEntryEntityCount::default()),
+    PerfUiWidgetBar::new(PerfUiEntryCpuUsage::default()),
+    PerfUiWidgetBar::new(PerfUiEntryMemUsage::default()),
+  ));
 }
 
-fn update_fps_system(diagnostics: Res<DiagnosticsStore>, mut query: Query<&mut TextSpan, With<FpsText>>) {
-  for mut span in &mut query {
-    if let Some(value) = diagnostics
-      .get(&FrameTimeDiagnosticsPlugin::FPS)
-      .and_then(|fps| fps.smoothed())
-    {
-      **span = format!("{value:>4.0}");
-    } else {
-      **span = " N/A".into();
-    }
-  }
-}
-
-fn toggle_fps_counter_event(
-  mut events: EventReader<ToggleDebugInfo>,
-  mut fps_ui_root: Query<&mut Visibility, With<FpsUiRoot>>,
-  settings: Res<Settings>,
-) {
+fn toggle_ui(mut events: EventReader<ToggleDebugInfo>, q_root: Query<Entity, With<PerfUiRoot>>, mut commands: Commands) {
   let event_count = events.read().count();
   if event_count > 0 {
-    for mut visibility in fps_ui_root.iter_mut() {
-      *visibility = match settings.general.enable_tile_debugging {
-        true => Visibility::Visible,
-        false => Visibility::Hidden,
-      };
+    if let Ok(e) = q_root.get_single() {
+      commands.entity(e).despawn_recursive();
+    } else {
+      add_perf_ui(commands);
     }
   }
 }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -7,6 +7,7 @@ use crate::resources::{
 use crate::states::{AppState, GenerationState};
 use bevy::app::{App, Plugin, Update};
 use bevy::input::ButtonInput;
+use bevy::log::*;
 use bevy::prelude::{EventWriter, KeyCode, Local, Res, ResMut, Resource, With, World};
 use bevy::window::PrimaryWindow;
 use bevy_inspector_egui::bevy_egui::EguiContext;
@@ -52,10 +53,15 @@ fn render_settings_ui_system(world: &mut World, mut disabled: Local<bool>) {
     return;
   }
 
-  let mut egui_context = world
+  let mut egui_context = if let Ok(context) = world
     .query_filtered::<&mut EguiContext, With<PrimaryWindow>>()
-    .single(world)
-    .clone();
+    .get_single(world)
+  {
+    context.clone()
+  } else {
+    warn_once!("No egui context found");
+    return;
+  };
 
   Window::new("Settings")
     .default_size([340.0, 600.0])


### PR DESCRIPTION
## Key change
- Stop spawning each tile sprite as a dedicated entity, resulting it up to >11k entities at any one time
- Draw all tiles from the same sprite sheet on a single `Mesh2d` based on whether they are animated (i.e. max. 2 entities per layer => <10 entities per chunk vs previously up to 1280 entities per chunk)
- The above...
    - Results in dramatic performance improvements, esp. at higher zoom levels and/or when chunks are persisted instead of de-spawned when out of sight
    - Fixes issue https://github.com/kimgoetzke/procedural-generation-2/issues/3

## Additional changes
- Stops nesting entities for each sprite under a dedicated tile entity which is a child of the chunk and instead spawns all tile mesh layer and object sprite entities directly under the chunk
   - Before:  `Chunk A` -> `Tile 1` -> `[ Sprite I, Sprite II, Sprite II ]` 
   - After:  `Chunk A` -> `[ Tile Mesh Layer 1, Tile Mesh Layer 2, ... ]`
- Fundamentally refactors the `world_generation_system` and `WorldGenerationComponent` by stopping parallel processing of multiple stages of the same component but making the code easier to understand/readable
- Fixes a bug that could crash the application because of race condition (caused by the lack of ordering between `prune_world_event` and `world_generation_system`)
- Fixes a bug where multi-tile object sprites could be incomplete along the outside of chunks (as the sprite completing the object was placed in the outermost row/column which is not rendered)
- Fixes a bug that could cause the UI to panic while already exiting the application
- Replaces my own FPS counter UI with the more detailed `iyes_perf_ui` diagnostics UI